### PR TITLE
chore: tell Dependabot to ignore essentia version bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,12 @@ updates:
     labels:
       - dependencies
     open-pull-requests-limit: 5
+    ignore:
+      # essentia is exact-pinned to a known-good pre-release dev build. Nightly
+      # dev bumps frequently ship wheels for only one Python ABI (e.g. dev1438
+      # was cp314-only), breaking our 3.10+ support, and can silently shift
+      # analysis numbers. Bump deliberately, with an analysis-output check.
+      - dependency-name: "essentia"
 
   - package-ecosystem: github-actions
     directory: "/"


### PR DESCRIPTION
essentia is exact-pinned to a known-good dev build. Nightly dev bumps often ship wheels for a single Python ABI (dev1438 was cp314-only, breaking 3.10+) and can shift analysis numbers. Bump it manually with a regression check instead of via Dependabot. Closes the recurring noise (see PR #29).

## Summary

Brief description of what this PR does and why.

## Changes

- ...
- ...

## Test Plan

How was this tested?

- [x] New tests added
- [x] Existing tests pass

## Checklist

- [x] Tests pass (`uv run pytest tests/ -x -q`)
- [x] Linting passes (`uv tool run ruff check src/ tests/`)
- [x] Formatting passes (`uv tool run ruff format --check src/ tests/`)

