### PR TITLE
Fix Phantom audit findings (2026-07-05)

### DIFF
--- a/scripts/bench_full_diagnostic.py
+++ b/scripts/bench_full_diagnostic.py
@@ -1,10 +1,18 @@
 """Timing harness for full_diagnostic on a 60 s stereo file (synthetic audio).
 
-Generates an in-memory 60 s stereo fixture (no real audio committed), warms
-up once, then reports the best-of-3 wall-clock time for full_diagnostic.
+Generates an in-memory 60 s stereo fixture (no real audio committed), then
+reports two numbers:
 
-Used as before/after evidence for the true-peak-once optimization (P-02) and
-re-used by later performance tasks on this branch.
+- COLD: best-of-3 wall-clock time for full_diagnostic with the shared
+  ``analysis_cache`` cleared before each run (and before warmup), so the timed
+  calls measure the actual analysis cost — apples-to-apples with the Task 6
+  baseline (2084.6 ms). This is the gate metric.
+- WARM: one re-run on the same bytes WITHOUT clearing the cache, measuring the
+  cache-hit path (a subsequent same-content tool call).
+
+Used as before/after evidence for the true-peak-once optimization (P-02), the
+content-hash memoization (P-01 follow-up), and re-used by later performance
+tasks on this branch.
 
 Run: uv run python scripts/bench_full_diagnostic.py
 """
@@ -16,10 +24,20 @@ import tempfile
 import numpy as np
 import soundfile as sf
 
+from phantom._cache import analysis_cache
 from phantom.server import full_diagnostic
 
 
-def _time_once(p: str) -> float:
+def _time_cold(p: str) -> float:
+    """Time one full_diagnostic with a freshly cleared cache (cold path)."""
+    analysis_cache.clear()
+    s = time.perf_counter()
+    full_diagnostic(p)
+    return time.perf_counter() - s
+
+
+def _time_warm(p: str) -> float:
+    """Time one full_diagnostic WITHOUT clearing (cache-hit path)."""
     s = time.perf_counter()
     full_diagnostic(p)
     return time.perf_counter() - s
@@ -40,9 +58,19 @@ def main() -> None:
         os.environ["PHANTOM_OUTPUT_DIR"] = d
         p = os.path.join(d, "bench.wav")
         sf.write(p, np.column_stack([left, right]), sr)
-        full_diagnostic(p)  # warmup
-        best = min(_time_once(p) for _ in range(3))
-    print(f"full_diagnostic 60s stereo: {best * 1000:.1f} ms (best of 3)")
+
+        # Warmup on the cold path (cache cleared) so JIT/import costs don't skew.
+        _time_cold(p)
+
+        # COLD: cache cleared before each run — measures true analysis cost.
+        cold = min(_time_cold(p) for _ in range(3))
+
+        # WARM: prime the cache once, then time a same-bytes re-run (cache hits).
+        full_diagnostic(p)
+        warm = min(_time_warm(p) for _ in range(3))
+
+    print(f"full_diagnostic 60s stereo COLD (cache cleared): {cold * 1000:.1f} ms (best of 3)")
+    print(f"full_diagnostic 60s stereo WARM (cache-hit path): {warm * 1000:.1f} ms (best of 3)")
 
 
 if __name__ == "__main__":

--- a/scripts/bench_full_diagnostic.py
+++ b/scripts/bench_full_diagnostic.py
@@ -1,0 +1,49 @@
+"""Timing harness for full_diagnostic on a 60 s stereo file (synthetic audio).
+
+Generates an in-memory 60 s stereo fixture (no real audio committed), warms
+up once, then reports the best-of-3 wall-clock time for full_diagnostic.
+
+Used as before/after evidence for the true-peak-once optimization (P-02) and
+re-used by later performance tasks on this branch.
+
+Run: uv run python scripts/bench_full_diagnostic.py
+"""
+
+import os
+import time
+import tempfile
+
+import numpy as np
+import soundfile as sf
+
+from phantom.server import full_diagnostic
+
+
+def _time_once(p: str) -> float:
+    s = time.perf_counter()
+    full_diagnostic(p)
+    return time.perf_counter() - s
+
+
+def main() -> None:
+    sr = 44100
+    n = sr * 60
+    t = np.arange(n) / sr
+    rng = np.random.default_rng(0)
+    left = (0.4 * np.sin(2 * np.pi * 220 * t) + 0.1 * rng.standard_normal(n)).astype(
+        "float32"
+    )
+    right = (0.4 * np.sin(2 * np.pi * 223 * t) + 0.1 * rng.standard_normal(n)).astype(
+        "float32"
+    )
+    with tempfile.TemporaryDirectory() as d:
+        os.environ["PHANTOM_OUTPUT_DIR"] = d
+        p = os.path.join(d, "bench.wav")
+        sf.write(p, np.column_stack([left, right]), sr)
+        full_diagnostic(p)  # warmup
+        best = min(_time_once(p) for _ in range(3))
+    print(f"full_diagnostic 60s stereo: {best * 1000:.1f} ms (best of 3)")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/bench_full_diagnostic.py
+++ b/scripts/bench_full_diagnostic.py
@@ -25,7 +25,9 @@ import numpy as np
 import soundfile as sf
 
 from phantom._cache import analysis_cache
+from phantom.audio import load_audio
 from phantom.server import full_diagnostic
+from phantom.spectral import _octave_band_energies, analyze_spectrum
 
 
 def _time_cold(p: str) -> float:
@@ -41,6 +43,43 @@ def _time_warm(p: str) -> float:
     s = time.perf_counter()
     full_diagnostic(p)
     return time.perf_counter() - s
+
+
+def _timed(fn) -> float:
+    """Return the wall-clock seconds to run ``fn`` once."""
+    s = time.perf_counter()
+    fn()
+    return time.perf_counter() - s
+
+
+def _probe_spectral(p: str) -> None:
+    """P-05 gate probe: time analyze_spectrum vs its octave-band pass alone.
+
+    ``analyze_spectrum`` makes two framed FFT passes over the same mono signal:
+    the main 2048/1024 spectral pass and the octave-band 4096/2048 pass (now in
+    ``_octave_band_energies``, shared with masking). The audit (P-05) proposed
+    fusing these into a single pass, but only if the band pass is a material
+    share of spectral time. This probe measures that share so the gate can be
+    decided from data.
+
+    Loads the fixture once, then times both on the same in-memory mono signal
+    (best of 3 each, after a warmup) so import/JIT costs don't skew the split.
+    """
+    audio = load_audio(p)
+    mono = audio.mono
+    sr = audio.sample_rate
+
+    # Warmup both paths so Essentia/JIT costs don't land in the timed runs.
+    analyze_spectrum(audio)
+    _octave_band_energies(mono, sr)
+
+    spectral_s = min(_timed(lambda: analyze_spectrum(audio)) for _ in range(3))
+    band_s = min(_timed(lambda: _octave_band_energies(mono, sr)) for _ in range(3))
+
+    share = (band_s / spectral_s * 100.0) if spectral_s > 0 else 0.0
+    print(f"P-05 probe -- analyze_spectrum 60s: {spectral_s * 1000:.1f} ms (best of 3)")
+    print(f"P-05 probe -- octave-band pass only: {band_s * 1000:.1f} ms (best of 3)")
+    print(f"P-05 probe -- band pass share of spectral: {share:.1f}%")
 
 
 def main() -> None:
@@ -69,8 +108,15 @@ def main() -> None:
         full_diagnostic(p)
         warm = min(_time_warm(p) for _ in range(3))
 
-    print(f"full_diagnostic 60s stereo COLD (cache cleared): {cold * 1000:.1f} ms (best of 3)")
-    print(f"full_diagnostic 60s stereo WARM (cache-hit path): {warm * 1000:.1f} ms (best of 3)")
+        print(
+            f"full_diagnostic 60s stereo COLD (cache cleared): {cold * 1000:.1f} ms (best of 3)"
+        )
+        print(
+            f"full_diagnostic 60s stereo WARM (cache-hit path): {warm * 1000:.1f} ms (best of 3)"
+        )
+
+        # P-05 gate probe: split analyze_spectrum time into its two FFT passes.
+        _probe_spectral(p)
 
 
 if __name__ == "__main__":

--- a/src/phantom/_cache.py
+++ b/src/phantom/_cache.py
@@ -45,6 +45,31 @@ class AnalysisCache:
     # Internal helpers
     # ------------------------------------------------------------------
 
+    def _content_digest(self, audio: AudioData) -> "hashlib._Hash":
+        """Return a SHA-256 object pre-fed with the per-instance content bytes.
+
+        The digest state (sample bytes + sample rate + channel count) is
+        per-instance-constant — samples are never mutated after construction
+        (established in Task 5's review) — so it is computed once and memoized
+        on the ``AudioData`` instance under ``_content_hash``. This is the same
+        ``audio.__dict__`` mechanism used for ``AudioData.mono`` (Task 5) and
+        ``_true_peaks`` (Task 6), and avoids re-hashing the (potentially large)
+        sample buffer on every cache ``get``/``put``.
+
+        Callers must ``.copy()`` the returned object before feeding the
+        per-function suffix so the memoized base state is never mutated.
+        """
+        cached = audio.__dict__.get("_content_hash")
+        if cached is not None:
+            return cached
+
+        h = hashlib.sha256()
+        h.update(audio.samples.tobytes())
+        h.update(str(audio.sample_rate).encode())
+        h.update(str(audio.num_channels).encode())
+        audio.__dict__["_content_hash"] = h
+        return h
+
     def _hash_audio(self, audio: AudioData, func_name: str) -> str:
         """Compute a SHA-256 cache key from audio content and function name.
 
@@ -53,11 +78,14 @@ class AnalysisCache:
         - Sample rate (same bytes at different rates = different audio)
         - Channel count (mono vs stereo reshape = different analysis)
         - Function name (prevents cross-function result collisions)
+
+        The content-digest portion (sample bytes + rate + channels) is memoized
+        per instance via :meth:`_content_digest`; only the cheap ``func_name``
+        suffix is fed per call. The resulting key is byte-identical to feeding
+        all four parts into a single fresh SHA-256, so the key format is
+        unchanged.
         """
-        h = hashlib.sha256()
-        h.update(audio.samples.tobytes())
-        h.update(str(audio.sample_rate).encode())
-        h.update(str(audio.num_channels).encode())
+        h = self._content_digest(audio).copy()
         h.update(func_name.encode())
         return h.hexdigest()
 
@@ -98,6 +126,15 @@ class AnalysisCache:
                     logger.debug(
                         "Cache evicted oldest entry (key=%s...)", evicted_key[:12]
                     )
+
+    def clear(self) -> None:
+        """Remove all cached entries.
+
+        Used to measure the cold (cache-miss) analysis path in the timing
+        harness, so successive runs don't measure cache hits.
+        """
+        with self._lock:
+            self._store.clear()
 
 
 # Module-level singleton for use by analysis/comparison modules.

--- a/src/phantom/_cache.py
+++ b/src/phantom/_cache.py
@@ -14,7 +14,7 @@ import hashlib
 import logging
 import threading
 from collections import OrderedDict
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Callable
 
 if TYPE_CHECKING:
     from phantom.audio import AudioData
@@ -102,3 +102,22 @@ class AnalysisCache:
 
 # Module-level singleton for use by analysis/comparison modules.
 analysis_cache = AnalysisCache()
+
+
+def _cached_analysis(
+    audio: AudioData, func_name: str, func: Callable[[AudioData], Any]
+) -> Any:
+    """Run an analysis function with cache lookup/store.
+
+    Checks the shared ``analysis_cache`` first. On miss, runs ``func(audio)``
+    and stores the result under ``func_name`` for subsequent calls with the
+    same audio content. Composite tools (``full_diagnostic``,
+    ``batch_diagnostic``), the ``analyze`` CLI, and the ``compare_*`` tools all
+    route through this helper so they share per-analyzer results (P-01).
+    """
+    result = analysis_cache.get(audio, func_name)
+    if result is not _MISSING:
+        return result
+    result = func(audio)
+    analysis_cache.put(audio, func_name, result)
+    return result

--- a/src/phantom/_resample.py
+++ b/src/phantom/_resample.py
@@ -82,3 +82,28 @@ def resample_to_match(audio: AudioData, target_sr: int) -> AudioData:
         num_samples=num_samples,
         file_path=audio.file_path,
     )
+
+
+def align_sample_rates(*audios: AudioData) -> tuple[AudioData, ...]:
+    """Upsample all inputs to the highest sample rate; identity when equal.
+
+    Returns the inputs in their original order.  When every input already
+    shares the same sample rate, the same objects are returned unchanged
+    (identity fast-path).  Otherwise each lower-rate input is upsampled to
+    ``max`` via :func:`resample_to_match`; inputs already at the target rate
+    are returned unchanged.
+
+    Args:
+        *audios: One or more :class:`AudioData` objects to align.
+
+    Returns:
+        A tuple of :class:`AudioData` in input order, all sharing the highest
+        sample rate among the inputs.
+    """
+    rates = {a.sample_rate for a in audios}
+    if len(rates) <= 1:
+        return tuple(audios)
+    target = max(rates)
+    return tuple(
+        resample_to_match(a, target) if a.sample_rate != target else a for a in audios
+    )

--- a/src/phantom/_truepeak.py
+++ b/src/phantom/_truepeak.py
@@ -1,0 +1,57 @@
+"""Shared per-channel true-peak computation (P-02, P-06).
+
+``es.TruePeakDetector`` (x4-oversampled FIR per ITU-R BS.1770-4) is the single
+most expensive operation in the analysis pipeline. Both loudness measurement
+and inter-sample-peak problem detection need it, and in ``full_diagnostic`` both
+run on the same file — previously computing it twice.
+
+``channel_true_peaks`` computes per-channel ``(sample_peak, true_peak)`` once and
+memoizes the result on the ``AudioData`` instance so loudness and problem
+detection share a single computation (P-02). A single ``TruePeakDetector`` is
+constructed and reused across channels (P-06); the detector is stateless across
+the two channels here (validated by the numeric-parity test in the suite).
+
+The memo lives in ``audio.__dict__["_true_peaks"]`` — the same mechanism
+``functools.cached_property`` uses for ``AudioData.mono`` / ``mono_rms``, and
+proven safe with this Pydantic v2 model.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import essentia.standard as es
+
+from phantom.audio import AudioData
+
+
+def channel_true_peaks(audio: AudioData) -> list[tuple[float, float]]:
+    """Per-channel ``(sample_peak, true_peak)`` via ITU-R BS.1770-4 x4 oversampling.
+
+    Constructs ONE ``TruePeakDetector`` and reuses it across channels (P-06).
+    The result is memoized on the ``AudioData`` instance so loudness and problem
+    detection share a single computation (P-02).
+
+    Args:
+        audio: AudioData object to analyze.
+
+    Returns:
+        A list of ``(sample_peak, true_peak)`` tuples, one per channel, where
+        both values are linear (not dB) absolute maxima.
+    """
+    cached = audio.__dict__.get("_true_peaks")
+    if cached is not None:
+        return cached
+
+    tp_algo = es.TruePeakDetector(
+        version=4, sampleRate=audio.sample_rate, oversamplingFactor=4
+    )
+    out: list[tuple[float, float]] = []
+    for ch in range(audio.num_channels):
+        sig = audio.samples[:, ch]
+        sample_peak = float(np.max(np.abs(sig))) if len(sig) else 0.0
+        _, tp_output = tp_algo(sig)
+        true_peak = float(np.max(np.abs(tp_output))) if len(tp_output) else 0.0
+        out.append((sample_peak, true_peak))
+
+    audio.__dict__["_true_peaks"] = out
+    return out

--- a/src/phantom/audio.py
+++ b/src/phantom/audio.py
@@ -13,6 +13,7 @@ Mono and stereo only (>2 channels rejected per AIO-03).
 from __future__ import annotations
 
 import os
+from functools import cached_property
 from typing import Optional
 
 import numpy as np
@@ -92,16 +93,24 @@ class AudioData(BaseModel):
             )
         return self.samples[:, 1]
 
-    @property
+    @cached_property
     def mono(self) -> np.ndarray:
-        """Return a mono mixdown of the audio.
+        """Return a (memoized) mono mixdown of the audio.
 
-        For mono input, returns samples[:, 0] directly.
-        For stereo input, returns the mean of left and right channels.
+        For mono input, returns samples[:, 0]. For stereo, the mean of the
+        first two channels. Computed once per instance (P-03).
         """
         if self.num_channels == 1:
             return self.samples[:, 0]
         return np.mean(self.samples[:, :2], axis=1)
+
+    @cached_property
+    def mono_rms(self) -> float:
+        """Full-signal RMS of the mono mixdown, computed once (P-04)."""
+        m = self.mono
+        if not np.issubdtype(m.dtype, np.floating):
+            m = m.astype(np.float64)
+        return float(np.sqrt(np.mean(m**2)))
 
 
 def load_audio(

--- a/src/phantom/cli/_formatting.py
+++ b/src/phantom/cli/_formatting.py
@@ -7,6 +7,7 @@ and error panel rendering used across all CLI subcommands.
 from __future__ import annotations
 
 import json
+import re
 import sys
 
 import plotext as plt
@@ -15,6 +16,12 @@ from rich.panel import Panel
 from rich.table import Table
 
 from phantom.exceptions import RECOMMENDED_PYTHON, DependencyMissingError, PhantomError
+
+# Local copy of server.py's _PATH_REGEX — strips Unix/Windows absolute paths from
+# error messages so CLI output never leaks internal filesystem layout. Kept as a
+# local copy (rather than importing from phantom.server) to avoid a CLI->server
+# import edge.
+_PATH_REGEX = re.compile(r"([A-Za-z]:\\[^\s:,)]+\\|/[^\s:,)]+/)+")
 
 # ---------------------------------------------------------------------------
 # Severity styling (D-06)
@@ -214,8 +221,9 @@ def render_error(exc: Exception, console: Console) -> None:
     """Render an exception as a styled Rich Panel.
 
     - ``DependencyMissingError``: yellow panel with install instructions
-    - ``PhantomError``: red panel with error message
-    - Other: red panel titled "Unexpected Error"
+    - ``PhantomError``: red panel with error message (absolute paths redacted)
+    - Other: red panel titled "Unexpected Error" with a generic message so
+      internal paths / details never leak (mirrors ``server.py``).
     """
     if isinstance(exc, DependencyMissingError):
         console.print(
@@ -229,7 +237,7 @@ def render_error(exc: Exception, console: Console) -> None:
     elif isinstance(exc, PhantomError):
         console.print(
             Panel(
-                str(exc),
+                _PATH_REGEX.sub("", str(exc)),
                 title="Error",
                 border_style="red",
             )
@@ -237,7 +245,7 @@ def render_error(exc: Exception, console: Console) -> None:
     else:
         console.print(
             Panel(
-                str(exc),
+                "Internal error — check the logs for details.",
                 title="Unexpected Error",
                 border_style="red",
             )

--- a/src/phantom/cli/analyze.py
+++ b/src/phantom/cli/analyze.py
@@ -17,8 +17,6 @@ from phantom import (
     analyze_phase,
     detect_problems,
     PhantomError,
-    ProblemItem,
-    ProblemsResult,
 )
 from phantom.cli._formatting import (
     get_console,
@@ -28,7 +26,7 @@ from phantom.cli._formatting import (
     output_json,
     render_error,
 )
-from phantom.problems import build_summary
+from phantom.problems import inject_sample_rate_mismatch
 
 
 # ---------------------------------------------------------------------------
@@ -157,8 +155,6 @@ def _detect_sample_rate_mismatch(
     if len(unique_rates) <= 1:
         return
 
-    mismatch_detail = {name: rate for name, rate in sample_rates.items()}
-
     for stem_name, stem_data in all_results.items():
         if "error" in stem_data:
             continue
@@ -167,19 +163,7 @@ def _detect_sample_rate_mismatch(
         if problems_result is None:
             continue
 
-        mismatch = ProblemItem(
-            type="sample_rate_mismatch",
-            severity="dealbreaker",
-            message=f"Sample rate mismatch across stems: {mismatch_detail}",
-            details={"sample_rates": mismatch_detail},
-        )
-
-        all_problems = [mismatch] + list(problems_result.problems)
-        rebuilt = ProblemsResult(
-            problems=all_problems,
-            clean=False,
-            summary=build_summary(all_problems),
-        )
+        rebuilt = inject_sample_rate_mismatch(problems_result, sample_rates)
 
         # Update results dict
         stem_data["results"]["problems"] = rebuilt

--- a/src/phantom/cli/analyze.py
+++ b/src/phantom/cli/analyze.py
@@ -47,11 +47,19 @@ _ANALYSIS_TYPES: dict[str, tuple] = {
 
 
 def _run_selected_analyses(audio, enabled: list[str]) -> dict:
-    """Run only the enabled analysis types and return results dict."""
+    """Run only the enabled analysis types and return results dict.
+
+    Each analyzer is routed through the shared ``analysis_cache`` via
+    ``_cached_analysis`` (P-01). The cache key is the analyzer's ``__name__``
+    (e.g. ``analyze_spectrum``), which matches the keys used by the MCP
+    composite tools and ``compare_*`` tools, so CLI and server share entries.
+    """
+    from phantom._cache import _cached_analysis
+
     results: dict = {}
     for name in enabled:
         fn, _title = _ANALYSIS_TYPES[name]
-        results[name] = fn(audio)
+        results[name] = _cached_analysis(audio, fn.__name__, fn)
     return results
 
 

--- a/src/phantom/cli/doctor.py
+++ b/src/phantom/cli/doctor.py
@@ -45,7 +45,7 @@ def _check_mcp_config(path: Path) -> bool | None:
 
 def _collect_results() -> dict:
     """Collect all diagnostic results into a dict."""
-    from phantom.cli.setup_reaper import _get_reaper_scripts_dir
+    from phantom.cli.setup_reaper import EXPECTED_LUA_FILES, _get_reaper_scripts_dir
 
     results: dict = {"ok": True}
 
@@ -95,7 +95,13 @@ def _collect_results() -> dict:
     # 7. Reaper integration
     install_dir = Path("~/.phantom/reaper-mcp").expanduser()
     scripts_dir = _get_reaper_scripts_dir()
-    lua_files = list(scripts_dir.glob("*.lua")) if scripts_dir.exists() else []
+    # Count only Phantom's own bridge script(s), not every unrelated .lua in the
+    # user's Reaper Scripts dir (P-21). Mirrors uninstall.py's filter.
+    lua_files = (
+        [f for f in scripts_dir.glob("*.lua") if f.name in EXPECTED_LUA_FILES]
+        if scripts_dir.exists()
+        else []
+    )
     results["reaper"] = {
         "bridge_installed": install_dir.exists(),
         "scripts_dir": str(scripts_dir),

--- a/src/phantom/cli/fix.py
+++ b/src/phantom/cli/fix.py
@@ -60,6 +60,11 @@ def fix(
 
     try:
         problems_filter: list[str] | None = None
+        # In interactive mode we decode the input once here for problem
+        # detection and thread it into fix_audio(audio=...) to avoid a second
+        # decode (P-08). Stays None in non-interactive mode, where fix_audio
+        # loads the file itself.
+        preloaded_audio = None
 
         if interactive:
             # Interactive mode: detect problems first, let user select
@@ -67,8 +72,8 @@ def fix(
                 "[bold blue]Analyzing audio problems...",
                 spinner="dots",
             ):
-                audio = load_audio(file)
-                problems_result = detect_problems(audio)
+                preloaded_audio = load_audio(file)
+                problems_result = detect_problems(preloaded_audio)
 
             if not problems_result.problems:
                 console.print("[bold green]No problems detected -- nothing to fix.")
@@ -145,6 +150,7 @@ def fix(
                 file,
                 problems=problems_filter,
                 output_path=output_path,
+                audio=preloaded_audio,
             )
 
         if json_output:

--- a/src/phantom/cli/render.py
+++ b/src/phantom/cli/render.py
@@ -173,6 +173,22 @@ def render(
         render_error(e, console)
         sys.exit(1)
 
+    # Self-overwrite guard (P-22). ffmpeg runs with `-y`, so if the output path
+    # resolves to the same file as the source (e.g. rendering x.wav to `wav`
+    # with no --output), the source would be clobbered in place. Refuse before
+    # any ffmpeg run. Compare realpaths so symlinks/relative paths can't slip by.
+    if os.path.realpath(output_path) == os.path.realpath(file):
+        console.print(
+            Panel(
+                "Output would overwrite the source file. Pass [bold]--output[/bold] "
+                "with a different path (or choose a different [bold]--format[/bold]) "
+                "so your original is preserved.",
+                title="Would Overwrite Source",
+                border_style="red",
+            )
+        )
+        sys.exit(1)
+
     # Build ffmpeg command as list (NEVER shell=True -- T-12-11).
     # Resource guards (Advisory 2): -max_alloc caps a single allocation;
     # -t (input option) bounds how much audio is decoded; -fs caps output size.

--- a/src/phantom/cli/render.py
+++ b/src/phantom/cli/render.py
@@ -176,8 +176,14 @@ def render(
     # Self-overwrite guard (P-22). ffmpeg runs with `-y`, so if the output path
     # resolves to the same file as the source (e.g. rendering x.wav to `wav`
     # with no --output), the source would be clobbered in place. Refuse before
-    # any ffmpeg run. Compare realpaths so symlinks/relative paths can't slip by.
-    if os.path.realpath(output_path) == os.path.realpath(file):
+    # any ffmpeg run. Compare realpaths so symlinks/relative paths can't slip by;
+    # also test os.path.samefile so same-inode collisions realpath does NOT
+    # normalize are caught -- hardlinks, and case-variant names on
+    # case-insensitive filesystems (macOS APFS), e.g. SONG.WAV -> SONG.wav.
+    same_target = os.path.realpath(output_path) == os.path.realpath(file) or (
+        os.path.exists(output_path) and os.path.samefile(output_path, file)
+    )
+    if same_target:
         console.print(
             Panel(
                 "Output would overwrite the source file. Pass [bold]--output[/bold] "

--- a/src/phantom/cli/separate.py
+++ b/src/phantom/cli/separate.py
@@ -28,7 +28,7 @@ from phantom.exceptions import PathSecurityError
     "--output-dir",
     "-o",
     default=None,
-    help="Output directory for stems (default: ./stems)",
+    help="Output directory for stems (default: stems/ in the Phantom output directory)",
 )
 @click.option(
     "--json",

--- a/src/phantom/cli/separate.py
+++ b/src/phantom/cli/separate.py
@@ -13,11 +13,13 @@ from phantom import (
     PhantomError,
     DependencyMissingError,
 )
+from phantom._utils import validate_output_path
 from phantom.cli._formatting import (
     get_console,
     output_json,
     render_error,
 )
+from phantom.exceptions import PathSecurityError
 
 
 @click.command()
@@ -42,8 +44,17 @@ def separate(file: str, output_dir: str | None, json_output: bool) -> None:
     """
     console = get_console(json_mode=json_output)
 
+    # Confine the default output dir (P-19). A bare "./stems" reads as
+    # CWD-relative; route the default through validate_output_path so it
+    # resolves to an explicit "stems/" under the confined output directory,
+    # matching how render resolves its default. Explicit --output-dir values
+    # are passed through unchanged (separate_stems validates them internally).
     if output_dir is None:
-        output_dir = "./stems"
+        try:
+            output_dir = validate_output_path("stems")
+        except PathSecurityError as exc:
+            render_error(exc, console)
+            sys.exit(1)
 
     try:
         with console.status(

--- a/src/phantom/cli/setup.py
+++ b/src/phantom/cli/setup.py
@@ -90,14 +90,23 @@ def _setup_plugin(console, json_mode: bool) -> dict:
     _PLUGIN_NAME = "phantom"
 
     try:
-        # Add marketplace if not already added
+        # Add marketplace. A nonzero exit here is usually benign (the marketplace
+        # is already registered), so we do NOT fail setup. But we no longer
+        # discard the result silently (P-18): a genuine failure (bad URL, network,
+        # git error) gets surfaced as a warning so the user knows why the plugin
+        # install below may not find anything.
         proc = subprocess.run(
             ["claude", "plugin", "marketplace", "add", _MARKETPLACE_URL],
             capture_output=True,
             text=True,
             timeout=60,
         )
-        # Ignore errors if already added
+        if proc.returncode != 0:
+            combined = (proc.stderr or "") + (proc.stdout or "")
+            already_added = "already" in combined.lower()
+            if not already_added and not json_mode:
+                excerpt = (proc.stderr or proc.stdout or "").strip()[:300]
+                console.print(f"  {WARN} Marketplace add failed: {excerpt}")
 
         # Install plugin
         proc = subprocess.run(

--- a/src/phantom/cli/setup_reaper.py
+++ b/src/phantom/cli/setup_reaper.py
@@ -274,21 +274,36 @@ def _render_mcp_diff(target: Path, old_text: str, new_text: str, console) -> Non
 def _remove_startup_block(content: str) -> str | None:
     """Strip the phantom auto-start block from __startup.lua content.
 
-    Returns the new content, or None if no phantom block is present.
+    Returns the new content, or None if no phantom block is present, or ""
+    when the file held only the phantom block.
+
+    The phantom block is delimited by ``_STARTUP_MARKER`` and the
+    ``-- [/phantom]`` end marker. If the opening marker has no matching end
+    marker (a hand-edited or corrupted file), the trailing lines are the
+    user's own content, not part of the phantom block — they are preserved
+    rather than deleted to EOF. Only the marker line itself is dropped.
     """
     if _STARTUP_MARKER not in content:
         return None
     lines = content.splitlines(keepends=True)
-    out, skipping = [], False
+    out: list[str] = []
+    buffered: list[str] = []  # lines seen after the marker, pending an end marker
+    skipping = False
     for line in lines:
         if _STARTUP_MARKER in line:
             skipping = True
+            buffered = []
             continue
         if skipping:
             if "-- [/phantom]" in line:
-                skipping = False
+                skipping = False  # well-formed block: discard buffered lines
+                buffered = []
+            else:
+                buffered.append(line)
             continue
         out.append(line)
+    # Opening marker never closed: the buffered lines are real user content.
+    out.extend(buffered)
     return "".join(out).rstrip() + "\n" if "".join(out).strip() else ""
 
 

--- a/src/phantom/cli/uninstall.py
+++ b/src/phantom/cli/uninstall.py
@@ -17,11 +17,11 @@ from rich.status import Status
 
 from phantom._utils import atomic_write_text
 from phantom.cli._formatting import get_console
+from phantom.cli.setup_reaper import _remove_startup_block
 
 _PHANTOM_DIR = Path("~/.phantom").expanduser()
 
 _STARTUP_MARKER = "-- [phantom] auto-start MCP bridge"
-_STARTUP_END = "-- [/phantom]"
 
 
 def _get_reaper_scripts_dir() -> Path:
@@ -111,29 +111,22 @@ def _remove_mcp_entries(
 def _remove_startup_hook(startup_path: str) -> bool:
     """Remove the Phantom auto-start block from __startup.lua.
 
-    Returns True iff the hook was successfully rewritten or removed.
+    Delegates the actual stripping to the single canonical implementation in
+    ``setup_reaper._remove_startup_block`` so both call sites handle every edge
+    (missing end marker, block-only file, no block) identically. This function
+    keeps the path I/O and the bool contract: True iff the hook was
+    successfully rewritten or removed (including the no-op "no phantom block"
+    case), False on any OS error.
     """
     path = Path(startup_path)
     try:
-        content = path.read_text()
-        lines = content.split("\n")
-        new_lines = []
-        skip = False
-        for line in lines:
-            if _STARTUP_MARKER in line:
-                skip = True
-                continue
-            if skip and _STARTUP_END in line:
-                skip = False
-                continue
-            if not skip:
-                new_lines.append(line)
-
-        new_content = "\n".join(new_lines).strip()
-        if new_content:
-            atomic_write_text(startup_path, new_content + "\n")
+        new_content = _remove_startup_block(path.read_text())
+        if new_content is None:
+            return True  # no phantom block present -- nothing to do
+        if new_content == "":
+            path.unlink()  # file held only the phantom block
         else:
-            path.unlink()
+            atomic_write_text(startup_path, new_content)
         return True
     except OSError:
         return False

--- a/src/phantom/cli/uninstall.py
+++ b/src/phantom/cli/uninstall.py
@@ -81,8 +81,11 @@ def _find_artifacts() -> dict:
 
 def _remove_mcp_entries(
     config_path: str, remove_phantom: bool, remove_reaper: bool
-) -> None:
-    """Remove phantom and/or reaper entries from an MCP config file."""
+) -> bool:
+    """Remove phantom and/or reaper entries from an MCP config file.
+
+    Returns True iff the config was successfully rewritten or removed.
+    """
     path = Path(config_path)
     try:
         data = json.loads(path.read_text())
@@ -100,12 +103,16 @@ def _remove_mcp_entries(
             atomic_write_text(config_path, json.dumps(data, indent=2) + "\n")
         else:
             path.unlink()
+        return True
     except (json.JSONDecodeError, OSError):
-        pass
+        return False
 
 
-def _remove_startup_hook(startup_path: str) -> None:
-    """Remove the Phantom auto-start block from __startup.lua."""
+def _remove_startup_hook(startup_path: str) -> bool:
+    """Remove the Phantom auto-start block from __startup.lua.
+
+    Returns True iff the hook was successfully rewritten or removed.
+    """
     path = Path(startup_path)
     try:
         content = path.read_text()
@@ -127,8 +134,38 @@ def _remove_startup_hook(startup_path: str) -> None:
             atomic_write_text(startup_path, new_content + "\n")
         else:
             path.unlink()
+        return True
     except OSError:
-        pass
+        return False
+
+
+def _uninstall_uv_package(console, removed: list[str]) -> None:
+    """Uninstall the phantom-audio uv tool package, recording the outcome."""
+    try:
+        proc = subprocess.run(
+            ["uv", "tool", "uninstall", "phantom-audio"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        console.print(
+            "[yellow]Could not uninstall package automatically (timed out). "
+            "Run: uv tool uninstall phantom-audio[/yellow]"
+        )
+        return
+
+    uv_output = (proc.stdout + proc.stderr).lower()
+
+    if proc.returncode == 0 or "uninstalled" in uv_output:
+        removed.append("phantom-audio package")
+    elif "not installed" in uv_output:
+        removed.append("phantom-audio package (already removed)")
+    else:
+        console.print(
+            "[yellow]Could not uninstall package automatically. "
+            "Run: uv tool uninstall phantom-audio[/yellow]"
+        )
 
 
 @click.command()
@@ -189,8 +226,13 @@ def uninstall(yes: bool, keep_config: bool) -> None:
 
     if not keep_config:
         for cfg in artifacts.get("mcp_configs", []):
-            _remove_mcp_entries(cfg["path"], cfg["has_phantom"], cfg["has_reaper"])
-            removed.append(f"MCP entries in {cfg['path']}")
+            if _remove_mcp_entries(cfg["path"], cfg["has_phantom"], cfg["has_reaper"]):
+                removed.append(f"MCP entries in {cfg['path']}")
+            else:
+                console.print(
+                    f"[yellow]Could not update {cfg['path']} -- remove the "
+                    "phantom/reaper entries manually.[/yellow]"
+                )
 
     if "reaper_bridge_data" in artifacts:
         shutil.rmtree(artifacts["reaper_bridge_data"], ignore_errors=True)
@@ -204,25 +246,15 @@ def uninstall(yes: bool, keep_config: bool) -> None:
             pass
 
     if "reaper_startup_hook" in artifacts:
-        _remove_startup_hook(artifacts["reaper_startup_hook"])
-        removed.append("Reaper auto-start hook")
+        if _remove_startup_hook(artifacts["reaper_startup_hook"]):
+            removed.append("Reaper auto-start hook")
+        else:
+            console.print(
+                f"[yellow]Could not update {artifacts['reaper_startup_hook']} -- "
+                "remove the phantom auto-start block manually.[/yellow]"
+            )
 
-    proc = subprocess.run(
-        ["uv", "tool", "uninstall", "phantom-audio"],
-        capture_output=True,
-        text=True,
-    )
-    uv_output = (proc.stdout + proc.stderr).lower()
-
-    if proc.returncode == 0 or "uninstalled" in uv_output:
-        removed.append("phantom-audio package")
-    elif "not installed" in uv_output:
-        removed.append("phantom-audio package (already removed)")
-    else:
-        console.print(
-            "[yellow]Could not uninstall package automatically. "
-            "Run: uv tool uninstall phantom-audio[/yellow]"
-        )
+    _uninstall_uv_package(console, removed)
 
     console.print(
         Panel(

--- a/src/phantom/cli/update.py
+++ b/src/phantom/cli/update.py
@@ -328,6 +328,9 @@ def update(yes: bool) -> None:
                 )
                 installed_pkg = _installed_package_spec(list_proc.stdout)
             except Exception:
+                # Intentional best-effort: if `uv tool list` fails or times out
+                # we can't detect extras, so we fall back to the bare package
+                # spec and let the reinstall proceed without preserving extras.
                 pass
             proc = subprocess.run(
                 ["uv", "tool", "install", "--force", installed_pkg],

--- a/src/phantom/cli/update.py
+++ b/src/phantom/cli/update.py
@@ -53,8 +53,34 @@ REQUEST_TIMEOUT = 5
 
 
 def _parse_version(tag: str) -> tuple[int, ...]:
-    """Parse 'v1.2.3' or '1.2.3' into (1, 2, 3)."""
-    return tuple(int(x) for x in tag.lstrip("v").split("."))
+    """Parse a release tag into a comparable numeric tuple.
+
+    Handles plain releases ('v1.2.3', '1.2.3', '1.2') and pre-release /
+    build-metadata suffixes ('1.2.3-rc1', '1.2.0b1', '2.0.0-beta',
+    'v1.2.3+build.5') without raising. The release segment is taken up to
+    the first '-' or '+'; numeric dot-components are converted until the
+    first non-numeric component, which is dropped along with anything after
+    it. Pre-release tags therefore sort as their release tuple — acceptable
+    because the only callers compare 'is latest strictly newer than current'
+    with identical normalization on both sides.
+    """
+    core = tag.lstrip("v")
+    # Cut any pre-release / build metadata suffix.
+    for sep in ("-", "+"):
+        core = core.split(sep, 1)[0]
+    parts: list[int] = []
+    for component in core.split("."):
+        # PEP 440-style inline suffixes like '0b1' -> take leading digits only.
+        digits = ""
+        for chdigit in component:
+            if chdigit.isdigit():
+                digits += chdigit
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
 
 
 def _fetch_json(url: str) -> dict | None:

--- a/src/phantom/cli/update.py
+++ b/src/phantom/cli/update.py
@@ -174,7 +174,13 @@ def check_for_update(force: bool = False) -> tuple[str, str] | None:
 
         _write_cache(latest, current)
         return (latest, current)
-    except Exception:
+    except (URLError, OSError, json.JSONDecodeError, ValueError, KeyError):
+        # Expected transient/data failures: network down (URLError/OSError;
+        # TimeoutError and socket errors are OSError subclasses), malformed JSON
+        # or timestamp (JSONDecodeError/ValueError), or a missing cache key
+        # (KeyError). Return None so callers degrade gracefully. Genuine
+        # programming errors (e.g. the P-11 parse bug) are intentionally NOT
+        # swallowed here and will surface.
         return None
 
 
@@ -303,6 +309,13 @@ def update(yes: bool) -> None:
             timeout=120,
         )
 
+        # NOTE (brittle, intentionally deferred): the extras-preserving reinstall
+        # fallback is gated on the exact substring "no such command" in uv's
+        # stderr (older uv builds lack `tool upgrade`). If uv reworded that
+        # message the fallback would silently stop firing. An exit-code-based
+        # rewrite was deferred by decision -- switching detection risks the
+        # upgrade path -- so the current string match is pinned by test
+        # `test_no_such_command_triggers_extras_preserving_reinstall`.
         if proc.returncode != 0 and "no such command" in proc.stderr.lower():
             # Detect current extras so reinstall preserves them (allowlisted only)
             installed_pkg = UV_INSTALL_PACKAGE

--- a/src/phantom/cli/update.py
+++ b/src/phantom/cli/update.py
@@ -295,29 +295,44 @@ def update(yes: bool) -> None:
 
     console.print(f"[dim]Installing phantom-audio {latest}...[/dim]")
 
-    proc = subprocess.run(
-        ["uv", "tool", "upgrade", UV_INSTALL_PACKAGE],
-        capture_output=True,
-        text=True,
-    )
-
-    if proc.returncode != 0 and "no such command" in proc.stderr.lower():
-        # Detect current extras so reinstall preserves them (allowlisted only)
-        installed_pkg = UV_INSTALL_PACKAGE
-        try:
-            list_proc = subprocess.run(
-                ["uv", "tool", "list", "--show-paths"],
-                capture_output=True,
-                text=True,
-            )
-            installed_pkg = _installed_package_spec(list_proc.stdout)
-        except Exception:
-            pass
+    try:
         proc = subprocess.run(
-            ["uv", "tool", "install", "--force", installed_pkg],
+            ["uv", "tool", "upgrade", UV_INSTALL_PACKAGE],
             capture_output=True,
             text=True,
+            timeout=120,
         )
+
+        if proc.returncode != 0 and "no such command" in proc.stderr.lower():
+            # Detect current extras so reinstall preserves them (allowlisted only)
+            installed_pkg = UV_INSTALL_PACKAGE
+            try:
+                list_proc = subprocess.run(
+                    ["uv", "tool", "list", "--show-paths"],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                installed_pkg = _installed_package_spec(list_proc.stdout)
+            except Exception:
+                pass
+            proc = subprocess.run(
+                ["uv", "tool", "install", "--force", installed_pkg],
+                capture_output=True,
+                text=True,
+                timeout=120,
+            )
+    except subprocess.TimeoutExpired:
+        console.print(
+            Panel(
+                "uv timed out while updating.\n\n"
+                "Check your network connection and try again, or update "
+                f"manually: [link={RELEASES_PAGE}]{RELEASES_PAGE}[/link]",
+                title="Update Failed",
+                border_style="red",
+            )
+        )
+        raise SystemExit(1) from None
 
     if proc.returncode == 0:
         _clear_cache()

--- a/src/phantom/comparison.py
+++ b/src/phantom/comparison.py
@@ -318,7 +318,7 @@ def _map_width_to_range(descriptor: str) -> tuple[float, float]:
     return _WIDTH_RANGES.get(descriptor, (0.0, 2.0))
 
 
-def _unmeasurable_deviation(key_name: str = "target") -> DeviationResult:
+def _unmeasurable_deviation() -> DeviationResult:
     return DeviationResult(rating="unmeasurable")
 
 
@@ -474,7 +474,7 @@ def compare_to_reference(
         if val_a is not None and val_b is not None:
             loudness_devs[key] = _rate_deviation_ref(val_a, val_b)
         else:
-            loudness_devs[key] = _unmeasurable_deviation("reference")
+            loudness_devs[key] = _unmeasurable_deviation()
 
     loudness_section = LoudnessReferenceComparisonSection(
         integrated_lufs=loudness_devs["integrated_lufs"],
@@ -497,11 +497,11 @@ def compare_to_reference(
                     norm_a[band_key], norm_b[band_key]
                 )
             else:
-                freq_result[band_key] = _unmeasurable_deviation("reference")
+                freq_result[band_key] = _unmeasurable_deviation()
     else:
         band_keys = (bands_a or bands_b or {}).keys()
         for band_key in band_keys:
-            freq_result[band_key] = _unmeasurable_deviation("reference")
+            freq_result[band_key] = _unmeasurable_deviation()
 
     # Dynamics
     dynamics_devs = {}
@@ -511,7 +511,7 @@ def compare_to_reference(
         if val_a is not None and val_b is not None:
             dynamics_devs[key] = _rate_deviation_ref(val_a, val_b)
         else:
-            dynamics_devs[key] = _unmeasurable_deviation("reference")
+            dynamics_devs[key] = _unmeasurable_deviation()
 
     dynamics_section = DynamicsReferenceComparisonSection(
         rms_dbfs=dynamics_devs["rms_dbfs"],
@@ -527,7 +527,7 @@ def compare_to_reference(
         if val_a is not None and val_b is not None:
             stereo_devs[key] = _rate_deviation_ref(val_a, val_b, round_fn=round_ratio)
         else:
-            stereo_devs[key] = _unmeasurable_deviation("reference")
+            stereo_devs[key] = _unmeasurable_deviation()
 
     stereo_section = StereoReferenceComparisonSection(
         correlation=stereo_devs["correlation"],

--- a/src/phantom/comparison.py
+++ b/src/phantom/comparison.py
@@ -16,7 +16,11 @@ from phantom._utils import (
     wrap_errors,
 )
 from phantom.audio import AudioData, load_audio
-from phantom._cache import _MISSING, analysis_cache
+
+# Re-exported for backward compatibility: existing callers/tests import
+# ``_cached_analysis`` from this module (see tests/test_comparison.py). The
+# canonical definition now lives in phantom._cache (P-01).
+from phantom._cache import _cached_analysis
 from phantom.dynamics import analyze_dynamics
 from phantom.exceptions import AnalysisError, AudioLoadError, DependencyMissingError
 from phantom.loudness import analyze_loudness
@@ -166,20 +170,6 @@ class MatchResult(BaseModel):
 # ---------------------------------------------------------------------------
 # Private Helpers
 # ---------------------------------------------------------------------------
-
-
-def _cached_analysis(audio: AudioData, func_name: str, func) -> object:
-    """Run an analysis function with cache lookup/store.
-
-    Checks the analysis cache first. On miss, runs the function and
-    stores the result for subsequent calls with the same audio.
-    """
-    result = analysis_cache.get(audio, func_name)
-    if result is not _MISSING:
-        return result
-    result = func(audio)
-    analysis_cache.put(audio, func_name, result)
-    return result
 
 
 def _classify_deviation(

--- a/src/phantom/dynamics.py
+++ b/src/phantom/dynamics.py
@@ -109,7 +109,7 @@ def analyze_dynamics(audio: AudioData) -> DynamicsResult:
             np.percentile(block_rms_db, 95) - np.percentile(block_rms_db, 5)
         )
     else:
-        dynamic_range_db = 0.0
+        dynamic_range_db = None  # Unmeasurable — too short to estimate (P-12)
 
     # -- Dynamic complexity (DYN-05) --
     dc = es.DynamicComplexity(sampleRate=audio.sample_rate, frameSize=0.2)

--- a/src/phantom/dynamics.py
+++ b/src/phantom/dynamics.py
@@ -91,7 +91,7 @@ def analyze_dynamics(audio: AudioData) -> DynamicsResult:
         return _silent_dynamics_result()
 
     # -- RMS level (DYN-01) --
-    rms = float(np.sqrt(np.mean(mono**2)))
+    rms = audio.mono_rms
     rms_dbfs = float(20 * np.log10(rms + 1e-10))
 
     # -- Peak level (DYN-02) --

--- a/src/phantom/loudness.py
+++ b/src/phantom/loudness.py
@@ -151,19 +151,13 @@ def analyze_loudness(audio: AudioData) -> LoudnessResult:
     # Measure true peak per channel and take the maximum.
     # ITU-R BS.1770-4 specifies that true peak is the maximum
     # true peak level across all channels.
-    eps = np.finfo(np.float32).eps
-    channel_peaks = []
-    for ch in range(audio.num_channels):
-        tp_algo = es.TruePeakDetector(
-            version=4,
-            sampleRate=sample_rate,
-            oversamplingFactor=4,
-        )
-        channel_signal = audio.samples[:, ch]
-        _, tp_output = tp_algo(channel_signal)
-        channel_peaks.append(float(np.max(np.abs(tp_output))))
+    # Computed once per file and memoized on the AudioData instance so
+    # detect_problems' inter-sample-peak detector shares it (P-02, P-06).
+    from phantom._truepeak import channel_true_peaks
 
-    max_tp = max(channel_peaks)
+    eps = np.finfo(np.float32).eps
+    peaks = channel_true_peaks(audio)
+    max_tp = max((tp for _sp, tp in peaks), default=0.0)
     true_peak_dbtp = float(20 * np.log10(max_tp + eps))
 
     return LoudnessResult(

--- a/src/phantom/masking.py
+++ b/src/phantom/masking.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import itertools
 
 import numpy as np
-import essentia.standard as es
 from pydantic import BaseModel, field_validator
 
 from phantom.audio import AudioData
@@ -20,7 +19,7 @@ from phantom.exceptions import AnalysisError
 from phantom._resample import resample_to_match
 from phantom._rounding import round_ratio
 from phantom._utils import is_near_silent, wrap_errors
-from phantom.spectral import OCTAVE_EDGES, _BAND_LABELS
+from phantom.spectral import _BAND_LABELS, _octave_band_energies
 
 # Severity thresholds for per-band overlap classification.
 _SEVERITY_HIGH = 0.6
@@ -140,6 +139,10 @@ def _no_masking_result() -> MaskingResult:
 def _compute_band_energies(mono: np.ndarray, sample_rate: int) -> np.ndarray:
     """Compute average energy per octave band using Essentia FrequencyBands.
 
+    Delegates to the shared ``spectral._octave_band_energies`` helper so the
+    4096/2048 Hann + ``FrequencyBands(OCTAVE_EDGES)`` loop lives in one place
+    (P-09). Numerically identical to the former inline implementation.
+
     Args:
         mono: 1D float32 numpy array of audio samples.
         sample_rate: Sample rate in Hz.
@@ -147,30 +150,7 @@ def _compute_band_energies(mono: np.ndarray, sample_rate: int) -> np.ndarray:
     Returns:
         1D numpy array of shape (10,) with average energy per octave band.
     """
-    frame_size = 4096
-    hop_size = 2048
-
-    # Audio shorter than one FFT frame cannot produce meaningful band energies.
-    # Zero energy is the acoustically correct answer — the signal contains
-    # insufficient data to resolve any frequency band.
-    if len(mono) < frame_size:
-        return np.zeros(len(_BAND_LABELS))
-
-    windowing = es.Windowing(type="hann", size=frame_size)
-    spectrum = es.Spectrum(size=frame_size)
-    freq_bands = es.FrequencyBands(frequencyBands=OCTAVE_EDGES, sampleRate=sample_rate)
-
-    band_energies_list = []
-    for frame in es.FrameGenerator(mono, frameSize=frame_size, hopSize=hop_size):
-        win = windowing(frame)
-        spec = spectrum(win)
-        bands = freq_bands(spec)
-        band_energies_list.append(bands)
-
-    if not band_energies_list:
-        return np.zeros(len(_BAND_LABELS))
-
-    return np.mean(band_energies_list, axis=0)
+    return _octave_band_energies(mono, sample_rate)
 
 
 def _compute_pairwise_result(

--- a/src/phantom/masking.py
+++ b/src/phantom/masking.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, field_validator
 
 from phantom.audio import AudioData
 from phantom.exceptions import AnalysisError
-from phantom._resample import align_sample_rates
+from phantom._resample import align_sample_rates, resample_to_match
 from phantom._rounding import round_ratio
 from phantom._utils import is_near_silent, wrap_errors
 from phantom.spectral import _BAND_LABELS, _octave_band_energies
@@ -255,8 +255,13 @@ def analyze_masking_matrix(stems: list[AudioData]) -> MaskingMatrixResult:
     Pre-computes band energies per stem to avoid redundant Essentia calls
     (per RESEARCH.md Pitfall 4).
 
-    If stems have different sample rates, all are automatically
-    upsampled to the highest rate.
+    If stems have different sample rates, all are automatically upsampled to the
+    highest rate. To bound peak memory (P-07), each stem is resampled to the
+    target rate one at a time via :func:`resample_to_match` -- the same per-stem
+    call :func:`align_sample_rates` makes internally -- and the resampled array
+    is dropped as soon as its band energies are computed, so at most one
+    resampled copy is held at a time rather than N. Results are identical to
+    aligning all stems up front.
 
     Args:
         stems: List of AudioData objects.
@@ -273,19 +278,25 @@ def analyze_masking_matrix(stems: list[AudioData]) -> MaskingMatrixResult:
     if n < 2:
         return MaskingMatrixResult(pairs=[], stem_count=n, pair_count=0)
 
-    # Auto-resample all stems to highest sample rate
-    stems = list(align_sample_rates(*stems))
+    # Target rate: upsample everything to the highest rate (upsample-only, per
+    # resample_to_match). Identity when all stems already share a rate.
+    target_sr = max(stem.sample_rate for stem in stems)
 
-    # Pre-compute band energies for all stems (optimization)
+    # Compute band energies per stem, streaming the resample: each stem is
+    # aligned to target_sr just-in-time and the resampled AudioData falls out of
+    # scope after its energies are read, so peak memory holds one resampled copy
+    # rather than N (P-07). Numerically identical to pre-aligning all stems.
     energies: list[np.ndarray | None] = []
     for stem in stems:
-        mono = stem.mono
+        aligned = resample_to_match(stem, target_sr)  # identity if already at target
+        mono = aligned.mono
         if len(mono) == 0:
             raise AnalysisError("Masking analysis failed: audio has 0 samples")
         if is_near_silent(mono):
             energies.append(None)  # marker for silent stems
         else:
-            energies.append(_compute_band_energies(mono, stem.sample_rate))
+            energies.append(_compute_band_energies(mono, aligned.sample_rate))
+        del aligned  # drop the resampled copy before the next iteration
 
     # Iterate all unique pairs
     pairs: list[MaskingPair] = []

--- a/src/phantom/masking.py
+++ b/src/phantom/masking.py
@@ -16,7 +16,7 @@ from pydantic import BaseModel, field_validator
 
 from phantom.audio import AudioData
 from phantom.exceptions import AnalysisError
-from phantom._resample import resample_to_match
+from phantom._resample import align_sample_rates
 from phantom._rounding import round_ratio
 from phantom._utils import is_near_silent, wrap_errors
 from phantom.spectral import _BAND_LABELS, _octave_band_energies
@@ -225,12 +225,7 @@ def analyze_masking(audio_a: AudioData, audio_b: AudioData) -> MaskingResult:
         AnalysisError: If audio is empty or analysis fails.
     """
     # Auto-resample on sample rate mismatch
-    if audio_a.sample_rate != audio_b.sample_rate:
-        target_sr = max(audio_a.sample_rate, audio_b.sample_rate)
-        if audio_a.sample_rate < target_sr:
-            audio_a = resample_to_match(audio_a, target_sr)
-        else:
-            audio_b = resample_to_match(audio_b, target_sr)
+    audio_a, audio_b = align_sample_rates(audio_a, audio_b)
 
     # Mono mixdown
     mono_a = audio_a.mono
@@ -279,13 +274,7 @@ def analyze_masking_matrix(stems: list[AudioData]) -> MaskingMatrixResult:
         return MaskingMatrixResult(pairs=[], stem_count=n, pair_count=0)
 
     # Auto-resample all stems to highest sample rate
-    rates = {s.sample_rate for s in stems}
-    if len(rates) > 1:
-        target_sr = max(rates)
-        stems = [
-            resample_to_match(s, target_sr) if s.sample_rate != target_sr else s
-            for s in stems
-        ]
+    stems = list(align_sample_rates(*stems))
 
     # Pre-compute band energies for all stems (optimization)
     energies: list[np.ndarray | None] = []

--- a/src/phantom/phase.py
+++ b/src/phantom/phase.py
@@ -25,7 +25,7 @@ from scipy.fft import fft, ifft
 
 from phantom.audio import AudioData
 from phantom.exceptions import AnalysisError
-from phantom._resample import resample_to_match
+from phantom._resample import align_sample_rates
 from phantom._rounding import round_ms, round_ratio
 from phantom._utils import _get_env_float, is_near_silent, wrap_errors
 
@@ -256,12 +256,7 @@ def compare_phase(audio1: AudioData, audio2: AudioData) -> PhaseCompareResult:
         AnalysisError: If audio has 0 samples or analysis fails.
     """
     # Auto-resample on sample rate mismatch
-    if audio1.sample_rate != audio2.sample_rate:
-        target_sr = max(audio1.sample_rate, audio2.sample_rate)
-        if audio1.sample_rate < target_sr:
-            audio1 = resample_to_match(audio1, target_sr)
-        else:
-            audio2 = resample_to_match(audio2, target_sr)
+    audio1, audio2 = align_sample_rates(audio1, audio2)
 
     mono1 = audio1.mono
     mono2 = audio2.mono

--- a/src/phantom/problems.py
+++ b/src/phantom/problems.py
@@ -115,6 +115,41 @@ def build_summary(problems: list[ProblemItem]) -> ProblemSummary:
     return ProblemSummary(**summary)
 
 
+def inject_sample_rate_mismatch(
+    problems_result: ProblemsResult,
+    sample_rates: dict,
+) -> ProblemsResult:
+    """Prepend a sample-rate-mismatch dealbreaker to a ProblemsResult (P-10).
+
+    Shared between the batch_diagnostic MCP tool (server.py) and the CLI batch
+    path (cli/analyze.py). Callers detect the mismatch (len(unique_rates) > 1)
+    and iterate over stems; this helper builds the dealbreaker ProblemItem from
+    ``sample_rates``, prepends it to ``problems_result.problems``, and returns a
+    freshly-built ProblemsResult with clean=False and an updated summary.
+
+    Args:
+        problems_result: The stem's existing ProblemsResult to augment.
+        sample_rates: Mapping of stem name -> sample rate (Hz) across the batch.
+
+    Returns:
+        A new ProblemsResult with the mismatch item first, clean=False, and a
+        summary rebuilt via build_summary. The input is not mutated.
+    """
+    mismatch_detail = {name: int(rate) for name, rate in sample_rates.items()}
+    mismatch = ProblemItem(
+        type="sample_rate_mismatch",
+        severity="dealbreaker",
+        message=f"Sample rate mismatch across stems: {mismatch_detail}",
+        details={"sample_rates": mismatch_detail},
+    )
+    all_problems = [mismatch] + list(problems_result.problems)
+    return ProblemsResult(
+        problems=all_problems,
+        clean=False,
+        summary=build_summary(all_problems),
+    )
+
+
 # ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------

--- a/src/phantom/problems.py
+++ b/src/phantom/problems.py
@@ -262,20 +262,13 @@ def _detect_dc_offset(mono: np.ndarray) -> list[ProblemItem]:
 
 def _detect_inter_sample_peaks(audio: AudioData) -> list[ProblemItem]:
     """Detect inter-sample peaks exceeding sample peak by >0.5 dB. PROB-03."""
-    eps = np.finfo(np.float32).eps
-    channel_results: list[tuple[float, float]] = []
+    # Reuse the per-file true-peak computation memoized by channel_true_peaks
+    # (shared with analyze_loudness) instead of running the x4-oversampled FIR
+    # a second time (P-02, P-06).
+    from phantom._truepeak import channel_true_peaks
 
-    for ch in range(audio.num_channels):
-        channel_signal = audio.samples[:, ch]
-        sample_peak = float(np.max(np.abs(channel_signal)))
-        if sample_peak < eps:
-            continue
-        tp = es.TruePeakDetector(
-            sampleRate=audio.sample_rate, oversamplingFactor=4, version=4
-        )
-        _, tp_output = tp(channel_signal)
-        true_peak = float(np.max(np.abs(tp_output)))
-        channel_results.append((sample_peak, true_peak))
+    eps = np.finfo(np.float32).eps
+    channel_results = [(sp, tp) for (sp, tp) in channel_true_peaks(audio) if sp >= eps]
 
     if not channel_results:
         return []

--- a/src/phantom/problems.py
+++ b/src/phantom/problems.py
@@ -184,7 +184,7 @@ def detect_problems(audio: AudioData) -> ProblemsResult:
 
     problems: list[ProblemItem] = []
     problems.extend(_detect_clipping(mono))
-    problems.extend(_detect_dc_offset(mono))
+    problems.extend(_detect_dc_offset(audio))
     problems.extend(_detect_inter_sample_peaks(audio))
     problems.extend(_detect_noise_floor(mono, audio.sample_rate))
     problems.extend(_detect_snr(mono, audio.sample_rate))
@@ -280,17 +280,47 @@ def _detect_clipping(mono: np.ndarray) -> list[ProblemItem]:
     ]
 
 
-def _detect_dc_offset(mono: np.ndarray) -> list[ProblemItem]:
-    """Detect non-zero DC offset. PROB-02."""
-    dc = float(np.mean(mono))
-    if abs(dc) < _DC_OFFSET_THRESHOLD:  # 0.05% of full scale — above 24-bit noise floor
+def _detect_dc_offset(audio: AudioData) -> list[ProblemItem]:
+    """Detect non-zero DC offset. PROB-02.
+
+    Checks DC per channel so antiphase DC (L=+x, R=-x), which cancels in the
+    mono mixdown, is still caught (P-13). Mono files are checked exactly as
+    before — the flagged item's shape is byte-identical to the pre-P-13 output.
+    Stereo files additionally emit a "channel" key naming the worst channel;
+    this is an additive detail field (existing keys preserved with the same
+    semantics).
+    """
+    if audio.num_channels == 1:
+        dc = float(np.mean(audio.mono))
+        if abs(dc) < _DC_OFFSET_THRESHOLD:  # 0.05% FS — above 24-bit noise floor
+            return []
+        return [
+            ProblemItem(
+                type="dc_offset",
+                severity="minor",
+                message=f"DC offset detected: {dc:.6f} (mean sample value).",
+                details={"dc_offset": round(dc, 8)},
+            )
+        ]
+
+    # Stereo: flag if EITHER channel exceeds the threshold. Report the channel
+    # with the largest magnitude DC (the worst offender).
+    left_dc = float(np.mean(audio.left))
+    right_dc = float(np.mean(audio.right))
+    if abs(left_dc) < _DC_OFFSET_THRESHOLD and abs(right_dc) < _DC_OFFSET_THRESHOLD:
         return []
+    if abs(left_dc) >= abs(right_dc):
+        dc, channel = left_dc, "left"
+    else:
+        dc, channel = right_dc, "right"
     return [
         ProblemItem(
             type="dc_offset",
             severity="minor",
-            message=f"DC offset detected: {dc:.6f} (mean sample value).",
-            details={"dc_offset": round(dc, 8)},
+            message=(
+                f"DC offset detected: {dc:.6f} (mean sample value, {channel} channel)."
+            ),
+            details={"dc_offset": round(dc, 8), "channel": channel},
         )
     ]
 

--- a/src/phantom/processing.py
+++ b/src/phantom/processing.py
@@ -26,7 +26,7 @@ from phantom._utils import (
     validate_output_path,
     wrap_errors,
 )
-from phantom.audio import load_audio
+from phantom.audio import AudioData, load_audio
 from phantom.problems import ProblemItem, ProblemsResult
 
 # ---------------------------------------------------------------------------
@@ -521,6 +521,8 @@ def fix_audio(
     file_path: str,
     problems: list[str] | None = None,
     output_path: str | None = None,
+    *,
+    audio: AudioData | None = None,
 ) -> FixResult:
     """Fix detected audio problems using recipe-based processing.
 
@@ -534,6 +536,13 @@ def fix_audio(
             fixes all detected fixable problems.
         output_path: Path for the processed output WAV file. If None,
             uses input stem + '_fixed.wav'.
+        audio: Optional already-loaded :class:`AudioData` for ``file_path``. When
+            provided (keyword-only), the internal ``load_audio(file_path)`` is
+            skipped and this data is reused, avoiding a redundant decode when the
+            caller already loaded the file (e.g. the interactive CLI path, P-08).
+            ``file_path`` is still validated and used for path checks and the
+            default output name. When ``None`` (the default), behavior is
+            byte-identical to loading the input internally.
 
     Returns:
         FixResult with output_path, fixes_applied, before/after
@@ -562,8 +571,11 @@ def fix_audio(
     file_path = validate_input_path(file_path)
     output_path = _resolve_output_path(file_path, output_path)
 
-    # Step 2: Load audio and detect problems (before)
-    audio = load_audio(file_path)
+    # Step 2: Load audio (unless the caller already did, P-08) and detect
+    # problems (before). validate_input_path above still guards the path; when
+    # `audio` is supplied it is reused verbatim so the input is decoded once.
+    if audio is None:
+        audio = load_audio(file_path)
     before = detect_problems(audio)
 
     # Step 3: Filter to fixable problems

--- a/src/phantom/separation.py
+++ b/src/phantom/separation.py
@@ -103,7 +103,12 @@ def separate_stems(input_path: str, output_dir: str) -> SeparationResult:
         channels=model.audio_channels,
     )
     ref = wav.mean(0)
-    wav = (wav - ref.mean()) / ref.std()
+    ref_std = float(ref.std())
+    if ref_std < 1e-12:
+        raise AnalysisError(
+            "Cannot separate a silent file — the input has no audible signal."
+        )
+    wav = (wav - ref.mean()) / ref_std
 
     # Step 5: Run separation (with timeout to prevent indefinite hangs)
     _SEPARATION_TIMEOUT = 600  # 10 minutes max for any file

--- a/src/phantom/server.py
+++ b/src/phantom/server.py
@@ -343,14 +343,21 @@ def _run_full_analysis(audio) -> dict:
     Returns a dict with keys: spectral, loudness, dynamics, stereo,
     phase, problems. Values are Pydantic model instances (not dumped dicts).
     Caller adds file-level metadata (file, duration, sample_rate, channels).
+
+    Each analyzer is routed through the shared ``analysis_cache`` via
+    ``_cached_analysis`` (P-01), so a subsequent ``compare_to_profile`` /
+    ``compare_to_reference`` on the same audio content reuses these results.
+    The cache keys match those used by the ``compare_*`` tools exactly.
     """
+    from phantom._cache import _cached_analysis
+
     return {
-        "spectral": _analyze_spectrum(audio),
-        "loudness": _analyze_loudness(audio),
-        "dynamics": _analyze_dynamics(audio),
-        "stereo": _analyze_stereo(audio),
-        "phase": _analyze_phase(audio),
-        "problems": _detect_problems(audio),
+        "spectral": _cached_analysis(audio, "analyze_spectrum", _analyze_spectrum),
+        "loudness": _cached_analysis(audio, "analyze_loudness", _analyze_loudness),
+        "dynamics": _cached_analysis(audio, "analyze_dynamics", _analyze_dynamics),
+        "stereo": _cached_analysis(audio, "analyze_stereo", _analyze_stereo),
+        "phase": _cached_analysis(audio, "analyze_phase", _analyze_phase),
+        "problems": _cached_analysis(audio, "detect_problems", _detect_problems),
     }
 
 

--- a/src/phantom/server.py
+++ b/src/phantom/server.py
@@ -26,8 +26,7 @@ from phantom.phase import analyze_phase as _analyze_phase, PhaseResult
 from phantom.phase import compare_phase as _compare_phase
 from phantom.problems import (
     detect_problems as _detect_problems,
-    ProblemItem,
-    build_summary,
+    inject_sample_rate_mismatch,
     ProblemsResult,
 )
 from phantom.masking import analyze_masking as _analyze_masking
@@ -443,20 +442,10 @@ def batch_diagnostic(file_paths: list[str]) -> dict:
     # SRV-04: Flag sample rate mismatches as dealbreaker
     unique_rates = set(sample_rates.values())
     if len(unique_rates) > 1:
-        mismatch_detail = {name: int(rate) for name, rate in sample_rates.items()}
         for stem_name, stem_result in results.items():
             if isinstance(stem_result, StemDiagnosticResult):
-                mismatch = ProblemItem(
-                    type="sample_rate_mismatch",
-                    severity="dealbreaker",
-                    message=f"Sample rate mismatch across stems: {mismatch_detail}",
-                    details={"sample_rates": mismatch_detail},
-                )
-                all_problems = [mismatch] + list(stem_result.problems.problems)
-                rebuilt = ProblemsResult(
-                    problems=all_problems,
-                    clean=False,
-                    summary=build_summary(all_problems),
+                rebuilt = inject_sample_rate_mismatch(
+                    stem_result.problems, sample_rates
                 )
                 results[stem_name] = stem_result.model_copy(
                     update={"problems": rebuilt}

--- a/src/phantom/spectral.py
+++ b/src/phantom/spectral.py
@@ -32,6 +32,49 @@ OCTAVE_EDGES = [OCTAVE_CENTERS[0] / _SQRT2] + [c * _SQRT2 for c in OCTAVE_CENTER
 _BAND_LABELS = [f"{int(c)}_hz" if c >= 1 else f"{c}_hz" for c in OCTAVE_CENTERS]
 
 
+def _octave_band_energies(mono: np.ndarray, sample_rate: int) -> np.ndarray:
+    """Average linear energy per octave band via Essentia FrequencyBands (P-09).
+
+    Runs a 4096/2048 Hann-windowed FrequencyBands loop over ``OCTAVE_EDGES``
+    and averages the per-frame band energies across all frames. Shared by both
+    ``analyze_spectrum`` (which converts the result to dB) and
+    ``masking._compute_band_energies`` (which consumes the linear energies
+    directly) so the identical loop is not duplicated.
+
+    Args:
+        mono: 1D float32 numpy array of audio samples.
+        sample_rate: Sample rate in Hz.
+
+    Returns:
+        1D numpy array of shape ``(len(OCTAVE_CENTERS),)`` with the average
+        linear energy per octave band. Returns all-zeros when the signal is
+        shorter than one 4096-sample frame (insufficient data to resolve any
+        band — the acoustically correct answer).
+    """
+    frame_size = 4096
+    hop_size = 2048
+
+    # Audio shorter than one FFT frame cannot produce meaningful band energies.
+    if len(mono) < frame_size:
+        return np.zeros(len(OCTAVE_CENTERS))
+
+    windowing = es.Windowing(type="hann", size=frame_size)
+    spectrum = es.Spectrum(size=frame_size)
+    freq_bands = es.FrequencyBands(frequencyBands=OCTAVE_EDGES, sampleRate=sample_rate)
+
+    band_energies_list = []
+    for frame in es.FrameGenerator(mono, frameSize=frame_size, hopSize=hop_size):
+        win = windowing(frame)
+        spec = spectrum(win)
+        bands = freq_bands(spec)
+        band_energies_list.append(bands)
+
+    if not band_energies_list:
+        return np.zeros(len(OCTAVE_CENTERS))
+
+    return np.mean(band_energies_list, axis=0)
+
+
 class SpectralResult(BaseModel):
     """Result of spectral analysis."""
 
@@ -153,26 +196,12 @@ def analyze_spectrum(audio: AudioData) -> SpectralResult:
     contrast_array = np.array(contrasts)
     mean_contrast = [float(v) for v in np.mean(contrast_array, axis=0)]
 
-    # Octave bands: 4096/2048 (~93ms/~46ms) — longer window for low-frequency resolution
-    band_frame_size = 4096
-    band_hop_size = 2048
+    # Octave bands: 4096/2048 (~93ms/~46ms) — longer window for low-frequency
+    # resolution. Shared with masking via _octave_band_energies (P-09).
+    avg_bands = _octave_band_energies(mono, sample_rate)
 
-    band_windowing = es.Windowing(type="hann", size=band_frame_size)
-    band_spectrum = es.Spectrum(size=band_frame_size)
-    freq_bands = es.FrequencyBands(frequencyBands=OCTAVE_EDGES, sampleRate=sample_rate)
-
-    band_energies_list = []
-    for frame in es.FrameGenerator(
-        mono, frameSize=band_frame_size, hopSize=band_hop_size
-    ):
-        win = band_windowing(frame)
-        spec = band_spectrum(win)
-        bands = freq_bands(spec)
-        band_energies_list.append(bands)
-
-    # Average across frames, convert to dB
+    # Convert to dB
     eps = 1e-10  # log-domain floor to avoid -inf on silence
-    avg_bands = np.mean(band_energies_list, axis=0)
     band_db = 10 * np.log10(avg_bands + eps)
 
     octave_band_energy = {

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -599,3 +599,46 @@ class TestUnsupportedFormats:
             AudioLoadError, match=r"phantom render track\.mp3 --format wav"
         ):
             load_audio(path)
+
+
+# ── Memoization guard tests (P-03, P-04) ───────────────────────────────
+
+
+class TestMonoMemoization:
+    """Guard tests for cached mono mixdown and full-signal RMS."""
+
+    def test_mono_is_memoized_same_object(self, stereo_sine_440hz):
+        """cached_property returns the identical array object on repeat access (P-03)."""
+        samples, sr = stereo_sine_440hz
+        audio = AudioData(
+            samples=samples,
+            sample_rate=sr,
+            num_channels=2,
+            duration=len(samples) / sr,
+            num_samples=len(samples),
+        )
+        m1 = audio.mono
+        m2 = audio.mono
+        assert m1 is m2  # cached_property returns the identical array object
+
+    def test_mono_rms_matches_manual(self, mono_sine_440hz):
+        """mono_rms equals the manual full-signal RMS of the mono mixdown (P-04).
+
+        mono_rms must reproduce the *exact* value the old ``dynamics.py``
+        computed (``float(np.sqrt(np.mean(mono**2)))`` on the float32 mono
+        signal) so the P-04 memoization is numerically transparent. We
+        therefore compute ``expected`` the same way — in the mono dtype,
+        without upcasting to float64. Upcasting first would introduce a
+        ~1e-8 float32/float64 accumulation gap and *change* the dynamics
+        RMS output, which this refactor must not do.
+        """
+        samples, sr = mono_sine_440hz
+        audio = AudioData(
+            samples=samples.reshape(-1, 1),
+            sample_rate=sr,
+            num_channels=1,
+            duration=len(samples) / sr,
+            num_samples=len(samples),
+        )
+        expected = float(np.sqrt(np.mean(audio.mono**2)))
+        assert audio.mono_rms == expected

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -7,7 +7,6 @@ import threading
 
 import numpy as np
 
-import phantom._cache as cache_mod
 from phantom._cache import _MISSING, AnalysisCache
 from phantom.audio import AudioData
 
@@ -77,8 +76,8 @@ class TestContentHashMemoization:
             calls["n"] += 1
             return real_sha256(*args, **kwargs)
 
-        # Patch the name where _cache looks it up.
-        monkeypatch.setattr(cache_mod.hashlib, "sha256", _counting_sha256)
+        # Patch the shared hashlib module object — the same one _cache looks up.
+        monkeypatch.setattr(hashlib, "sha256", _counting_sha256)
 
         # Two independent cache operations on the same instance: a put and a get.
         cache.put(audio, "spectrum", {"centroid": 1200.0})

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import hashlib
 import threading
 
 import numpy as np
 
+import phantom._cache as cache_mod
 from phantom._cache import _MISSING, AnalysisCache
 from phantom.audio import AudioData
 
@@ -47,6 +49,65 @@ class TestCacheGetPut:
         audio = _make_audio(np.zeros(100, dtype=np.float32), sr=44100)
         cache.put(audio, "spectrum", {"centroid": 1200.0})
         assert cache.get(audio, "loudness") is _MISSING
+
+    def test_clear_empties_the_cache(self) -> None:
+        cache = AnalysisCache(max_entries=4)
+        audio = _make_audio(np.zeros(100, dtype=np.float32), sr=44100)
+        cache.put(audio, "spectrum", {"centroid": 1200.0})
+        cache.clear()
+        assert cache.get(audio, "spectrum") is _MISSING
+
+
+class TestContentHashMemoization:
+    """The expensive per-instance content digest is computed only once (P-01 follow-up).
+
+    Two cache operations on the SAME AudioData instance must hash the sample
+    bytes exactly once — the content digest is memoized on the instance, mirroring
+    the ``AudioData.mono`` / ``_true_peaks`` memoization from Tasks 5–6.
+    """
+
+    def test_content_digest_computed_once_across_two_ops(self, monkeypatch) -> None:
+        cache = AnalysisCache(max_entries=4)
+        audio = _make_audio(np.full(100, 0.25, dtype=np.float32), sr=44100)
+
+        calls = {"n": 0}
+        real_sha256 = hashlib.sha256
+
+        def _counting_sha256(*args, **kwargs):
+            calls["n"] += 1
+            return real_sha256(*args, **kwargs)
+
+        # Patch the name where _cache looks it up.
+        monkeypatch.setattr(cache_mod.hashlib, "sha256", _counting_sha256)
+
+        # Two independent cache operations on the same instance: a put and a get.
+        cache.put(audio, "spectrum", {"centroid": 1200.0})
+        cache.get(audio, "spectrum")
+
+        assert calls["n"] == 1, (
+            "Expected the sample-bytes SHA-256 base to be constructed exactly once "
+            "across two cache operations on the same AudioData instance (memoized "
+            f"content digest), got {calls['n']}"
+        )
+
+    def test_memoized_key_matches_unmemoized_digest(self) -> None:
+        """The memoized key must be byte-identical to a fresh full-content SHA-256.
+
+        Guards against a key-format change: a cold instance (no memo) and the
+        canonical one-pass computation must agree.
+        """
+        cache = AnalysisCache(max_entries=4)
+        audio = _make_audio(np.full(100, 0.25, dtype=np.float32), sr=44100)
+
+        # Canonical one-pass digest (the pre-optimization formula).
+        h = hashlib.sha256()
+        h.update(audio.samples.tobytes())
+        h.update(str(audio.sample_rate).encode())
+        h.update(str(audio.num_channels).encode())
+        h.update("spectrum".encode())
+        expected = h.hexdigest()
+
+        assert cache._hash_audio(audio, "spectrum") == expected
 
 
 class TestCacheKeyDifferentiation:

--- a/tests/test_cli_analyze.py
+++ b/tests/test_cli_analyze.py
@@ -288,3 +288,39 @@ def test_analyze_batch_json_mismatch(runner, make_wav):
                     found_mismatch = True
                     break
     assert found_mismatch, "Expected sample_rate_mismatch problem in batch JSON output"
+
+
+# ---------------------------------------------------------------------------
+# Shared analysis cache population (P-01)
+# ---------------------------------------------------------------------------
+
+
+def test_analyze_cli_populates_cache(mono_sine_440hz, make_wav):
+    """The analyze CLI routes analyzers through the shared analysis cache (P-01).
+
+    _run_selected_analyses keys the cache via each analyzer's __name__, matching
+    the keys used by the MCP composite/compare tools (see the server-side
+    test_full_diagnostic_populates_cache twin). Running it must populate
+    analysis_cache under those shared key names so a later compare_* / server
+    call on the same bytes reuses the work.
+    """
+    from phantom._cache import _MISSING, analysis_cache
+    from phantom.audio import load_audio
+    from phantom.cli.analyze import _run_selected_analyses
+
+    # Start from a clean cache so the assertions reflect this call only.
+    analysis_cache.clear()
+
+    samples, sr = mono_sine_440hz
+    path = make_wav(samples, sr)
+    audio = load_audio(path)
+
+    _run_selected_analyses(audio, ["spectral", "loudness", "problems"])
+
+    # Entries stored under the analyzer __name__ keys shared with the server.
+    assert analysis_cache.get(audio, "analyze_spectrum") is not _MISSING
+    assert analysis_cache.get(audio, "analyze_loudness") is not _MISSING
+    assert analysis_cache.get(audio, "detect_problems") is not _MISSING
+
+    # Clean up so we don't leak entries into other tests sharing the cache.
+    analysis_cache.clear()

--- a/tests/test_cli_doctor.py
+++ b/tests/test_cli_doctor.py
@@ -83,3 +83,22 @@ def test_doctor_json_broken_core_dep(runner):
     data = json.loads(result.output)
     assert data["ok"] is False
     assert data["core_deps"]["numpy"]["ok"] is False
+
+
+def test_doctor_counts_only_bridge_lua(runner, tmp_path):
+    """Only the known bridge lua counts, not unrelated .lua files (P-21)."""
+    import json
+
+    scripts_dir = tmp_path / "Scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "reaper_mcp_bridge.lua").write_text("-- bridge")
+    (scripts_dir / "other.lua").write_text("-- unrelated")
+
+    with patch(
+        "phantom.cli.setup_reaper._get_reaper_scripts_dir",
+        return_value=scripts_dir,
+    ):
+        result = runner.invoke(cli, ["doctor", "--json"])
+
+    data = json.loads(result.output)
+    assert data["reaper"]["lua_scripts_found"] == 1

--- a/tests/test_cli_fix.py
+++ b/tests/test_cli_fix.py
@@ -292,3 +292,60 @@ def test_fix_interactive_hides_unfixable(runner, mono_sine_440hz, make_wav):
     # Should mention unfixable count
     assert "cannot be auto-fixed" in result.output.lower()
     assert "clipping" in result.output.lower()
+
+
+# ---------------------------------------------------------------------------
+# P-08: interactive mode threads the already-loaded audio into fix_audio
+# ---------------------------------------------------------------------------
+
+
+def test_fix_interactive_passes_preloaded_audio(runner, mono_sine_440hz, make_wav):
+    """--interactive threads the AudioData it loaded into fix_audio(audio=...).
+
+    Avoids a second decode of the input: the audio detect_problems ran on is
+    the same object passed to fix_audio.
+    """
+    from phantom.audio import AudioData
+
+    samples, sr = mono_sine_440hz
+    path = make_wav(samples, sr)
+
+    mock_problems = ProblemsResult(
+        problems=[
+            ProblemItem(
+                type="mud", severity="moderate", message="Mud detected", details={}
+            ),
+        ],
+        clean=False,
+    )
+    mock_result = _make_mock_fix_result(path.replace(".wav", "_fixed.wav"))
+
+    with (
+        patch("phantom.cli.fix.detect_problems", return_value=mock_problems),
+        patch("phantom.cli.fix.fix_audio", return_value=mock_result) as mock_fix,
+        patch("phantom.cli.fix.Prompt.ask", return_value="all"),
+    ):
+        result = runner.invoke(cli, ["fix", "--interactive", path])
+
+    assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
+    mock_fix.assert_called_once()
+    passed_audio = mock_fix.call_args[1].get("audio")
+    assert isinstance(passed_audio, AudioData), (
+        "Expected interactive mode to pass the loaded AudioData as audio="
+    )
+
+
+def test_fix_non_interactive_passes_no_preloaded_audio(
+    runner, mono_sine_440hz, make_wav
+):
+    """Non-interactive mode passes audio=None; fix_audio loads the file itself."""
+    samples, sr = mono_sine_440hz
+    path = make_wav(samples, sr)
+    mock_result = _make_mock_fix_result(path.replace(".wav", "_fixed.wav"))
+
+    with patch("phantom.cli.fix.fix_audio", return_value=mock_result) as mock_fix:
+        result = runner.invoke(cli, ["fix", path])
+
+    assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
+    mock_fix.assert_called_once()
+    assert mock_fix.call_args[1].get("audio") is None

--- a/tests/test_cli_formatting.py
+++ b/tests/test_cli_formatting.py
@@ -142,13 +142,38 @@ def test_render_error_dependency_missing():
 
 
 def test_render_error_generic_exception():
-    """Generic exceptions render as Unexpected Error panel."""
+    """Generic exceptions render as Unexpected Error panel with a safe message."""
     buf = io.StringIO()
     console = Console(file=buf, force_terminal=True)
     render_error(ValueError("something went wrong"), console)
     output = buf.getvalue()
-    assert "something went wrong" in output
+    # The raw exception text must not leak; a generic message is shown instead.
+    assert "something went wrong" not in output
     assert "Unexpected Error" in output
+
+
+def test_render_error_generic_for_unexpected(capsys):
+    from rich.console import Console
+    from phantom.cli._formatting import render_error
+
+    console = Console()
+    exc = RuntimeError("boom at /Users/secret/private/track.wav internal detail")
+    render_error(exc, console)
+    out = capsys.readouterr().out
+    assert "/Users/secret/private" not in out
+    assert "internal detail" not in out
+    assert "check server logs" in out.lower() or "unexpected error" in out.lower()
+
+
+def test_render_error_phantom_redacts_paths(capsys):
+    from rich.console import Console
+    from phantom.exceptions import AudioLoadError
+    from phantom.cli._formatting import render_error
+
+    console = Console()
+    render_error(AudioLoadError("Cannot read /Users/x/secret/a.wav here"), console)
+    out = capsys.readouterr().out
+    assert "/Users/x/secret" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_formatting.py
+++ b/tests/test_cli_formatting.py
@@ -157,10 +157,10 @@ def test_render_error_generic_for_unexpected(capsys):
     from phantom.cli._formatting import render_error
 
     console = Console()
-    exc = RuntimeError("boom at /Users/secret/private/track.wav internal detail")
+    exc = RuntimeError("boom at /private/studio-sessions/track.wav internal detail")
     render_error(exc, console)
     out = capsys.readouterr().out
-    assert "/Users/secret/private" not in out
+    assert "/private/studio-sessions" not in out
     assert "internal detail" not in out
     assert "check server logs" in out.lower() or "unexpected error" in out.lower()
 
@@ -171,9 +171,11 @@ def test_render_error_phantom_redacts_paths(capsys):
     from phantom.cli._formatting import render_error
 
     console = Console()
-    render_error(AudioLoadError("Cannot read /Users/x/secret/a.wav here"), console)
+    render_error(
+        AudioLoadError("Cannot read /private/secret-sessions/a.wav here"), console
+    )
     out = capsys.readouterr().out
-    assert "/Users/x/secret" not in out
+    assert "/private/secret-sessions" not in out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli_render.py
+++ b/tests/test_cli_render.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -342,6 +343,56 @@ class TestRenderSelfOverwrite:
                     "wav",
                     "--output",
                     str(wav_path),
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "overwrite" in result.output.lower()
+        assert wav_path.read_bytes() == original_bytes
+
+    def test_render_hardlink_to_source_blocked(
+        self, runner, tmp_path, mono_sine_440hz, monkeypatch
+    ):
+        """An --output that is a hardlink of the source is blocked (same inode).
+
+        realpath does NOT collapse a hardlink to its source path (both names are
+        real, distinct paths), so the realpath-string guard alone misses this
+        case. On case-insensitive filesystems (macOS APFS) the equivalent trap is
+        a case-variant of the source name -- also a same-inode collision that
+        realpath won't normalize. A hardlink reproduces the same-inode condition
+        deterministically on every filesystem, so we assert the os.samefile arm
+        of the guard catches it and leaves the source bytes untouched.
+        """
+        monkeypatch.delenv("PHANTOM_AUDIO_DIR", raising=False)
+        monkeypatch.setenv("PHANTOM_OUTPUT_DIR", str(tmp_path))
+
+        wav_path = tmp_path / "source.wav"
+        samples, sr = mono_sine_440hz
+        sf.write(str(wav_path), samples, sr)
+        original_bytes = wav_path.read_bytes()
+
+        # A second name for the exact same inode; realpath(link) != realpath(src)
+        # as strings, but os.path.samefile(link, src) is True.
+        link_path = tmp_path / "alias.wav"
+        os.link(str(wav_path), str(link_path))
+
+        mock_ff_cls = MagicMock(
+            side_effect=AssertionError("ffmpeg must not run on self-overwrite")
+        )
+
+        with (
+            patch("phantom.cli.render.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("ffmpeg_progress_yield.FfmpegProgress", mock_ff_cls),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "render",
+                    str(wav_path),
+                    "--format",
+                    "wav",
+                    "--output",
+                    str(link_path),
                 ],
             )
 

--- a/tests/test_cli_render.py
+++ b/tests/test_cli_render.py
@@ -261,3 +261,90 @@ class TestRenderPathSecurity:
         output_lower = result.output.lower()
         assert "denied" not in output_lower and "outside" not in output_lower
         assert "ffmpeg" in output_lower
+
+
+# ---------------------------------------------------------------------------
+# Self-overwrite guard tests (P-22)
+# ---------------------------------------------------------------------------
+
+
+class TestRenderSelfOverwrite:
+    """Render must refuse to overwrite its own source file (P-22)."""
+
+    def test_render_wav_to_wav_default_output_blocked(
+        self, runner, tmp_path, mono_sine_440hz, monkeypatch
+    ):
+        """Rendering a .wav to `wav` with no --output would overwrite the source.
+
+        The default output path is the input name with the new extension; for a
+        .wav rendered to `wav` that equals the source. render must error out and
+        leave the source bytes untouched, before any ffmpeg run.
+        """
+        monkeypatch.delenv("PHANTOM_AUDIO_DIR", raising=False)
+        # Confine output to the source's directory so the default output path
+        # (source.wav) passes validate_output_path -- isolating the
+        # self-overwrite guard as the reason for the failure rather than
+        # path confinement.
+        monkeypatch.setenv("PHANTOM_OUTPUT_DIR", str(tmp_path))
+
+        wav_path = tmp_path / "source.wav"
+        samples, sr = mono_sine_440hz
+        sf.write(str(wav_path), samples, sr)
+        original_bytes = wav_path.read_bytes()
+
+        # If the guard fails and ffmpeg were reachable, -y would clobber the
+        # source. Patch FfmpegProgress to fail loudly if it is ever constructed.
+        mock_ff_cls = MagicMock(
+            side_effect=AssertionError("ffmpeg must not run on self-overwrite")
+        )
+
+        with (
+            patch("phantom.cli.render.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("ffmpeg_progress_yield.FfmpegProgress", mock_ff_cls),
+        ):
+            result = runner.invoke(cli, ["render", str(wav_path), "--format", "wav"])
+
+        assert result.exit_code != 0
+        output_lower = result.output.lower()
+        assert "overwrite" in output_lower
+        assert "--output" in result.output
+        # Source bytes must be unchanged.
+        assert wav_path.read_bytes() == original_bytes
+
+    def test_render_explicit_output_equals_source_blocked(
+        self, runner, tmp_path, mono_sine_440hz, monkeypatch
+    ):
+        """An explicit --output pointing at the source is also blocked (realpath)."""
+        monkeypatch.delenv("PHANTOM_AUDIO_DIR", raising=False)
+        # Confine output to the source's directory so the explicit path validates,
+        # isolating the self-overwrite guard as the reason for the failure.
+        monkeypatch.setenv("PHANTOM_OUTPUT_DIR", str(tmp_path))
+
+        wav_path = tmp_path / "source.wav"
+        samples, sr = mono_sine_440hz
+        sf.write(str(wav_path), samples, sr)
+        original_bytes = wav_path.read_bytes()
+
+        mock_ff_cls = MagicMock(
+            side_effect=AssertionError("ffmpeg must not run on self-overwrite")
+        )
+
+        with (
+            patch("phantom.cli.render.shutil.which", return_value="/usr/bin/ffmpeg"),
+            patch("ffmpeg_progress_yield.FfmpegProgress", mock_ff_cls),
+        ):
+            result = runner.invoke(
+                cli,
+                [
+                    "render",
+                    str(wav_path),
+                    "--format",
+                    "wav",
+                    "--output",
+                    str(wav_path),
+                ],
+            )
+
+        assert result.exit_code != 0
+        assert "overwrite" in result.output.lower()
+        assert wav_path.read_bytes() == original_bytes

--- a/tests/test_cli_separate.py
+++ b/tests/test_cli_separate.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import patch
 
 import pytest
@@ -149,3 +150,45 @@ def test_separate_custom_output_dir(runner, mono_sine_440hz, make_wav, tmp_path)
 
     assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
     mock_fn.assert_called_once_with(path, custom_dir)
+
+
+# ---------------------------------------------------------------------------
+# Default output dir confinement (P-19)
+# ---------------------------------------------------------------------------
+
+
+def test_separate_default_output_dir_confined(
+    runner, mono_sine_440hz, make_wav, tmp_path, monkeypatch
+):
+    """The default output dir resolves under the confined output directory.
+
+    With no --output-dir, the CLI must route the default through
+    validate_output_path (matching render's default handling) so the dir passed
+    to separate_stems sits under PHANTOM_OUTPUT_DIR rather than being a bare
+    CWD-relative './stems'.
+    """
+    from phantom._utils import validate_output_path
+
+    monkeypatch.delenv("PHANTOM_AUDIO_DIR", raising=False)
+    out_dir = tmp_path / "confined_out"
+    out_dir.mkdir()
+    monkeypatch.setenv("PHANTOM_OUTPUT_DIR", str(out_dir))
+
+    samples, sr = mono_sine_440hz
+    path = make_wav(samples, sr)
+    mock_result = _make_mock_result(tmp_path)
+
+    with patch(
+        "phantom.cli.separate.separate_stems", return_value=mock_result
+    ) as mock_fn:
+        result = runner.invoke(cli, ["separate", path])
+
+    assert result.exit_code == 0, f"Exit {result.exit_code}: {result.output}"
+    mock_fn.assert_called_once()
+    passed_dir = mock_fn.call_args.args[1]
+    # The resolved default must be an absolute path confined under the output dir
+    # (i.e. validate_output_path accepts it and returns it unchanged).
+    assert os.path.isabs(passed_dir), f"default dir not absolute: {passed_dir}"
+    assert validate_output_path(passed_dir) == os.path.realpath(passed_dir)
+    real_base = os.path.realpath(str(out_dir))
+    assert os.path.realpath(passed_dir).startswith(real_base + os.sep)

--- a/tests/test_cli_setup.py
+++ b/tests/test_cli_setup.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from click.testing import CliRunner
@@ -68,6 +68,56 @@ class TestPluginSetup:
         result = runner.invoke(cli, ["setup", "--skip-plugin", "--skip-reaper"])
         assert result.exit_code == 0
         assert "skipped" in result.output.lower()
+
+
+class TestMarketplaceFailure:
+    """The discarded `marketplace add` result is now surfaced (P-18)."""
+
+    def _fake_run_factory(self, add_returncode, add_stderr):
+        """Build a subprocess.run stub: fail marketplace add, succeed install."""
+
+        def fake_run(cmd, **kwargs):
+            proc = MagicMock()
+            if cmd[:4] == ["claude", "plugin", "marketplace", "add"]:
+                proc.returncode = add_returncode
+                proc.stderr = add_stderr
+                proc.stdout = ""
+            else:  # plugin install
+                proc.returncode = 0
+                proc.stdout = "installed"
+                proc.stderr = ""
+            return proc
+
+        return fake_run
+
+    def test_genuine_marketplace_failure_warns(self, runner, clean_env):
+        """A real marketplace add failure prints a yellow warning with stderr."""
+        fake_run = self._fake_run_factory(
+            add_returncode=1, add_stderr="fatal: could not read from remote repository"
+        )
+        with (
+            patch("phantom.cli.setup.shutil.which", return_value="/usr/bin/claude"),
+            patch("phantom.cli.setup.subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(cli, ["setup", "--skip-reaper"])
+        # Setup must NOT fail on a marketplace hiccup.
+        assert result.exit_code == 0
+        assert "arketplace" in result.output
+        assert "could not read from remote repository" in result.output
+
+    def test_already_added_marketplace_stays_quiet(self, runner, clean_env):
+        """An 'already exists' marketplace add does not print a warning."""
+        fake_run = self._fake_run_factory(
+            add_returncode=1, add_stderr="marketplace 'phantom' already exists"
+        )
+        with (
+            patch("phantom.cli.setup.shutil.which", return_value="/usr/bin/claude"),
+            patch("phantom.cli.setup.subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(cli, ["setup", "--skip-reaper"])
+        assert result.exit_code == 0
+        # Plugin still installs; no marketplace warning line.
+        assert "Marketplace add failed" not in result.output
 
 
 class TestReaperSetup:

--- a/tests/test_cli_uninstall.py
+++ b/tests/test_cli_uninstall.py
@@ -185,6 +185,31 @@ class TestRemoveStartupHook:
         ok = uninstall._remove_startup_hook(str(startup))
         assert ok is False
 
+    def test_missing_end_marker_preserves_trailing_lines(self, tmp_path):
+        """A phantom block missing its ``-- [/phantom]`` end marker must not
+        swallow the user's trailing content (the old uninstall bug deleted to
+        EOF once the skip flag latched).
+        """
+        from phantom.cli import uninstall
+
+        startup = tmp_path / "__startup.lua"
+        startup.write_text(
+            "-- user header line\n"
+            "-- [phantom] auto-start MCP bridge\n"
+            "dofile(reaper.GetResourcePath())\n"
+            "-- (end marker was manually deleted)\n"
+            "dofile('user_own_script.lua')\n"
+            "-- user trailing line\n"
+        )
+        ok = uninstall._remove_startup_hook(str(startup))
+        assert ok is True
+        content = startup.read_text()
+        # The marker line itself is stripped, but real user content survives.
+        assert "auto-start MCP bridge" not in content
+        assert "user header line" in content
+        assert "user_own_script.lua" in content
+        assert "user trailing line" in content
+
 
 # ---------------------------------------------------------------------------
 # phantom uninstall command
@@ -206,7 +231,13 @@ class TestUninstallCommand:
     def test_uninstall_with_yes(self, runner, phantom_dir):
         mock_proc = MagicMock()
         mock_proc.returncode = 0
-        with patch("phantom.cli.uninstall.subprocess.run", return_value=mock_proc):
+        # Run in an isolated cwd so the --yes uninstall can't rewrite the
+        # developer's real ./.mcp.json (which would strip the phantom entry and
+        # trip the CLI group's first-run auto-setup in later tests).
+        with (
+            runner.isolated_filesystem(),
+            patch("phantom.cli.uninstall.subprocess.run", return_value=mock_proc),
+        ):
             result = runner.invoke(cli, ["uninstall", "--yes"])
             assert result.exit_code == 0
             assert "Uninstalled" in result.output or "removed" in result.output.lower()

--- a/tests/test_cli_uninstall.py
+++ b/tests/test_cli_uninstall.py
@@ -109,6 +109,34 @@ class TestRemoveMcpEntries:
         _remove_mcp_entries(str(cfg), remove_phantom=True, remove_reaper=False)
         assert not cfg.exists()
 
+    def test_remove_mcp_entries_returns_false_on_write_error(
+        self, tmp_path, monkeypatch
+    ):
+        # A write failure must be reported, not silently swallowed (P-15).
+        from phantom.cli import uninstall
+
+        cfg = tmp_path / "config.json"
+        cfg.write_text('{"mcpServers": {"phantom": {}, "other": {}}}')
+
+        def _boom(*a, **k):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(uninstall, "atomic_write_text", _boom)
+        ok = uninstall._remove_mcp_entries(
+            str(cfg), remove_phantom=True, remove_reaper=False
+        )
+        assert ok is False
+
+    def test_remove_mcp_entries_returns_true_on_success(self, tmp_path):
+        from phantom.cli import uninstall
+
+        cfg = tmp_path / "config.json"
+        cfg.write_text('{"mcpServers": {"phantom": {}, "other": {}}}')
+        ok = uninstall._remove_mcp_entries(
+            str(cfg), remove_phantom=True, remove_reaper=False
+        )
+        assert ok is True
+
 
 # ---------------------------------------------------------------------------
 # _remove_startup_hook
@@ -142,6 +170,21 @@ class TestRemoveStartupHook:
         _remove_startup_hook(str(startup))
         assert not startup.exists()
 
+    def test_remove_startup_hook_returns_false_on_error(self, tmp_path, monkeypatch):
+        from phantom.cli import uninstall
+
+        startup = tmp_path / "__startup.lua"
+        startup.write_text(
+            "-- [phantom] auto-start MCP bridge\nfoo()\n-- [/phantom]\nkeep()\n"
+        )
+
+        def _boom(*a, **k):
+            raise OSError("read-only fs")
+
+        monkeypatch.setattr(uninstall, "atomic_write_text", _boom)
+        ok = uninstall._remove_startup_hook(str(startup))
+        assert ok is False
+
 
 # ---------------------------------------------------------------------------
 # phantom uninstall command
@@ -172,3 +215,22 @@ class TestUninstallCommand:
         result = runner.invoke(cli, ["uninstall"], input="n\n")
         assert "Phantom Artifacts Found" in result.output
         assert "phantom-audio" in result.output
+
+    def test_uv_uninstall_has_timeout(self, monkeypatch):
+        # The uv tool uninstall call must pass a timeout (P-16).
+        from phantom.cli import uninstall
+
+        captured = {}
+
+        class _Proc:
+            returncode = 0
+            stdout = "uninstalled phantom-audio"
+            stderr = ""
+
+        def _fake_run(cmd, **kwargs):
+            captured.update(kwargs)
+            return _Proc()
+
+        monkeypatch.setattr(uninstall.subprocess, "run", _fake_run)
+        uninstall._uninstall_uv_package(uninstall.get_console(), [])
+        assert "timeout" in captured and captured["timeout"] == 30

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -134,6 +134,29 @@ class TestCheckForUpdate:
         with patch("phantom.cli.update.urlopen", side_effect=OSError("no network")):
             assert check_for_update(force=True) is None
 
+    def test_returns_none_on_urlerror(self, cache_dir):
+        """A URLError network failure still degrades to None (P-21 narrowed catch)."""
+        from urllib.error import URLError
+
+        with patch(
+            "phantom.cli.update.urlopen", side_effect=URLError("connection refused")
+        ):
+            assert check_for_update(force=True) is None
+
+    def test_programming_error_is_not_swallowed(self, cache_dir):
+        """The narrowed catch must let genuine bugs surface, not mask them (P-21).
+
+        A TypeError (a stand-in for a programming error like the fixed P-11 parse
+        bug) is outside the caught tuple, so it propagates instead of being
+        silently turned into None.
+        """
+        with patch(
+            "phantom.cli.update._fetch_latest_version",
+            side_effect=TypeError("unexpected programming bug"),
+        ):
+            with pytest.raises(TypeError):
+                check_for_update(force=True)
+
     def test_returns_versions_when_release_exists(self, cache_dir):
         resp = _mock_urlopen({"tag_name": "v1.2.0"})
         with patch("phantom.cli.update.urlopen", return_value=resp):
@@ -401,6 +424,75 @@ class TestUpdateCommand:
         assert recorded_kwargs, "expected subprocess.run to be called"
         for kwargs in recorded_kwargs:
             assert "timeout" in kwargs, f"missing timeout in call kwargs: {kwargs}"
+
+    def test_no_such_command_triggers_extras_preserving_reinstall(
+        self, runner, cache_dir
+    ):
+        """Pin the string-match fallback: "no such command" -> list + install (P-18).
+
+        This locks the CURRENT (intentionally deferred) detection behavior. If uv
+        reworded its error, this test breaks -- which is the signal that the
+        fallback needs revisiting rather than silently disabling.
+        """
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            proc = MagicMock()
+            if cmd[:3] == ["uv", "tool", "upgrade"]:
+                proc.returncode = 1
+                proc.stderr = "error: no such command 'upgrade'"
+            else:
+                proc.returncode = 0
+                proc.stdout = "phantom-audio v1.1.0 (/path)\n"
+                proc.stderr = ""
+            return proc
+
+        with (
+            patch(
+                "phantom.cli.update.check_for_update",
+                return_value=("2.0.0", "1.1.0"),
+            ),
+            patch("phantom.cli.update.is_editable_install", return_value=False),
+            patch("phantom.cli.update.subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(cli, ["update", "--yes"])
+
+        assert result.exit_code == 0
+        # Fallback fired: upgrade, then list, then force-install.
+        assert calls[0][:3] == ["uv", "tool", "upgrade"]
+        assert any(c[:3] == ["uv", "tool", "list"] for c in calls)
+        assert any(c[:3] == ["uv", "tool", "install"] for c in calls)
+
+    def test_other_uv_error_does_not_trigger_reinstall(self, runner, cache_dir):
+        """A nonzero exit WITHOUT "no such command" must NOT fire the fallback (P-18).
+
+        Pins the specificity of the string match: only the exact uv wording
+        triggers the extras-preserving reinstall.
+        """
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            proc = MagicMock()
+            proc.returncode = 1
+            proc.stderr = "error: some other failure"
+            proc.stdout = ""
+            return proc
+
+        with (
+            patch(
+                "phantom.cli.update.check_for_update",
+                return_value=("2.0.0", "1.1.0"),
+            ),
+            patch("phantom.cli.update.is_editable_install", return_value=False),
+            patch("phantom.cli.update.subprocess.run", side_effect=fake_run),
+        ):
+            result = runner.invoke(cli, ["update", "--yes"])
+
+        assert result.exit_code != 0
+        # Only the single upgrade call was made; no list/install fallback.
+        assert calls == [["uv", "tool", "upgrade", "phantom-audio"]]
 
     def test_timeout_renders_update_failed(self, runner, cache_dir):
         """A subprocess timeout surfaces the Update Failed panel, not a hang (P-16)."""

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib.metadata
 import json
+import subprocess
 from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock, patch
 
@@ -364,6 +365,55 @@ class TestUpdateCommand:
             ),
             patch("phantom.cli.update.is_editable_install", return_value=False),
             patch("phantom.cli.update.subprocess.run", return_value=mock_proc),
+        ):
+            result = runner.invoke(cli, ["update", "--yes"])
+            assert result.exit_code != 0
+            assert "Failed" in result.output
+
+    def test_all_subprocess_calls_have_timeout(self, runner, cache_dir):
+        """Every uv subprocess call in `update` must pass a timeout (P-16)."""
+        recorded_kwargs = []
+
+        def fake_run(cmd, **kwargs):
+            recorded_kwargs.append(kwargs)
+            proc = MagicMock()
+            # First call (upgrade) triggers the list + install fallback path so
+            # all three subprocess calls are exercised.
+            if cmd[:3] == ["uv", "tool", "upgrade"]:
+                proc.returncode = 1
+                proc.stderr = "error: no such command 'upgrade'"
+            else:
+                proc.returncode = 0
+                proc.stdout = "phantom-audio v1.1.0 (/path)\n"
+                proc.stderr = ""
+            return proc
+
+        with (
+            patch(
+                "phantom.cli.update.check_for_update",
+                return_value=("2.0.0", "1.1.0"),
+            ),
+            patch("phantom.cli.update.is_editable_install", return_value=False),
+            patch("phantom.cli.update.subprocess.run", side_effect=fake_run),
+        ):
+            runner.invoke(cli, ["update", "--yes"])
+
+        assert recorded_kwargs, "expected subprocess.run to be called"
+        for kwargs in recorded_kwargs:
+            assert "timeout" in kwargs, f"missing timeout in call kwargs: {kwargs}"
+
+    def test_timeout_renders_update_failed(self, runner, cache_dir):
+        """A subprocess timeout surfaces the Update Failed panel, not a hang (P-16)."""
+        with (
+            patch(
+                "phantom.cli.update.check_for_update",
+                return_value=("2.0.0", "1.1.0"),
+            ),
+            patch("phantom.cli.update.is_editable_install", return_value=False),
+            patch(
+                "phantom.cli.update.subprocess.run",
+                side_effect=subprocess.TimeoutExpired(cmd="uv", timeout=120),
+            ),
         ):
             result = runner.invoke(cli, ["update", "--yes"])
             assert result.exit_code != 0

--- a/tests/test_cli_update.py
+++ b/tests/test_cli_update.py
@@ -68,6 +68,24 @@ class TestParseVersion:
     def test_comparison_older(self):
         assert _parse_version("1.0.0") < _parse_version("1.1.0")
 
+    def test_parse_version_prerelease_rc(self):
+        # Regression: pre-release suffixes must not raise (P-11).
+        assert _parse_version("1.2.3-rc1") == (1, 2, 3)
+
+    def test_parse_version_prerelease_beta_pep440(self):
+        assert _parse_version("1.2.0b1") == (1, 2, 0)
+
+    def test_parse_version_prerelease_dashed_beta(self):
+        assert _parse_version("2.0.0-beta") == (2, 0, 0)
+
+    def test_parse_version_build_metadata(self):
+        assert _parse_version("v1.2.3+build.5") == (1, 2, 3)
+
+    def test_parse_version_prerelease_orders_below_next_release(self):
+        # A suffixed latest tag must still compare cleanly against current.
+        assert _parse_version("1.3.1") < _parse_version("1.4.0-rc1")
+        assert _parse_version("1.3.1-rc1") <= _parse_version("1.3.1")
+
 
 # ---------------------------------------------------------------------------
 # is_editable_install

--- a/tests/test_comparison.py
+++ b/tests/test_comparison.py
@@ -15,6 +15,7 @@ from phantom.comparison import (
     _normalize_band_energies,
     _rate_deviation,
     _rate_range_deviation,
+    _unmeasurable_deviation,
     compare_to_profile,
     compare_to_reference,
     match_to_reference,
@@ -204,6 +205,12 @@ class TestDeviationRating:
         result = _rate_range_deviation(value=12.0, target_range=(6.0, 12.0))
         assert result.rating == "on_target"
         assert result.deviation == 0.0
+
+    def test_unmeasurable_deviation(self):
+        """_unmeasurable_deviation() returns a DeviationResult rated 'unmeasurable'."""
+        result = _unmeasurable_deviation()
+        assert isinstance(result, DeviationResult)
+        assert result.rating == "unmeasurable"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dynamics.py
+++ b/tests/test_dynamics.py
@@ -166,6 +166,26 @@ class TestDynamicRange:
         assert result.dynamic_range_db > 10.0
 
 
+def test_dynamic_range_none_for_ultrashort_audio():
+    # < 2 RMS blocks => unmeasurable, not a misleading 0.0 (P-12).
+    import numpy as np
+    from phantom.audio import AudioData
+    from phantom.dynamics import analyze_dynamics
+
+    sr = 44100
+    # ~2048 samples (< 2 blocks at 4096/2048) but above the silence floor.
+    samples = (np.sin(2 * np.pi * 440 * np.arange(2048) / sr) * 0.5).astype("float32")
+    audio = AudioData(
+        samples=samples.reshape(-1, 1),
+        sample_rate=sr,
+        num_channels=1,
+        duration=2048 / sr,
+        num_samples=2048,
+    )
+    result = analyze_dynamics(audio)
+    assert result.dynamic_range_db is None
+
+
 # ---------------------------------------------------------------------------
 # DYN-05: Dynamic Complexity
 # ---------------------------------------------------------------------------

--- a/tests/test_loudness.py
+++ b/tests/test_loudness.py
@@ -405,8 +405,8 @@ class TestSharedTruePeak:
         (two independent per-channel loops) it is 4 for stereo.
         """
         import essentia.standard as es
-        import phantom.loudness as loudness_mod
         import phantom.problems as problems_mod
+        from phantom.loudness import es as loudness_es
 
         calls = {"n": 0}
         real_ctor = es.TruePeakDetector
@@ -416,14 +416,12 @@ class TestSharedTruePeak:
             return real_ctor(*args, **kwargs)
 
         # Patch the name where each module looks it up (both import es).
-        monkeypatch.setattr(loudness_mod.es, "TruePeakDetector", _counting_ctor)
+        monkeypatch.setattr(loudness_es, "TruePeakDetector", _counting_ctor)
         monkeypatch.setattr(problems_mod.es, "TruePeakDetector", _counting_ctor)
 
         audio = _asymmetric_stereo()
         analyze_loudness(audio)
-        from phantom.problems import detect_problems
-
-        detect_problems(audio)
+        problems_mod.detect_problems(audio)
 
         assert calls["n"] == 1, (
             f"Expected TruePeakDetector constructed exactly once across "

--- a/tests/test_loudness.py
+++ b/tests/test_loudness.py
@@ -339,3 +339,94 @@ class TestLufsStats:
             val = getattr(stats, field)
             # Check at most 2 decimal places
             assert val == round(val, 2)
+
+
+# ---------------------------------------------------------------------------
+# Shared true-peak (P-02 + P-06): compute once, byte-identical to legacy
+# ---------------------------------------------------------------------------
+
+
+def _asymmetric_stereo(sr: int = 44100) -> AudioData:
+    """Asymmetric stereo fixture: left near full scale, right much quieter.
+
+    Distinct per-channel content proves that reusing a single
+    TruePeakDetector across channels stays stateless (parity gate).
+    """
+    t = np.linspace(0, 2.0, sr * 2, endpoint=False, dtype=np.float32)
+    left = (0.95 * np.sin(2 * np.pi * 14700 * t)).astype(np.float32)
+    right = (0.2 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+    stereo = np.column_stack([left, right])
+    return AudioData(
+        samples=stereo,
+        sample_rate=sr,
+        num_channels=2,
+        duration=len(left) / sr,
+        num_samples=len(left),
+    )
+
+
+class TestSharedTruePeak:
+    """P-02 + P-06: true peak computed once, byte-identical to per-channel legacy."""
+
+    def test_true_peak_matches_legacy_perchannel(self):
+        """dBTP must match a fresh-per-channel detector to <1e-6 on asymmetric stereo.
+
+        This also validates that reusing ONE TruePeakDetector across the two
+        channels (P-06) is safe: if Essentia were stateful across calls, the
+        shared-detector path would diverge from this per-channel-fresh legacy.
+        """
+        import essentia.standard as es
+
+        audio = _asymmetric_stereo()
+        samples = audio.samples
+        sr = audio.sample_rate
+
+        eps = np.finfo(np.float32).eps
+        peaks = []
+        for ch in range(2):
+            tp = es.TruePeakDetector(version=4, sampleRate=sr, oversamplingFactor=4)
+            _, o = tp(samples[:, ch])
+            peaks.append(float(np.max(np.abs(o))))
+        legacy = float(20 * np.log10(max(peaks) + eps))
+
+        result = analyze_loudness(audio)
+        # LoudnessResult rounds true_peak_dbtp to 1 decimal via round_db, so
+        # compare against the same rounding of the legacy value.
+        from phantom._rounding import round_db
+
+        assert abs(result.true_peak_dbtp - round_db(legacy)) < 1e-6
+
+    def test_true_peak_computed_once(self, monkeypatch):
+        """analyze_loudness then detect_problems on the SAME AudioData constructs
+        es.TruePeakDetector exactly once.
+
+        Spy on the essentia constructor and count instances built across both
+        calls. On the shared-memo implementation this is 1; on the legacy code
+        (two independent per-channel loops) it is 4 for stereo.
+        """
+        import essentia.standard as es
+        import phantom.loudness as loudness_mod
+        import phantom.problems as problems_mod
+
+        calls = {"n": 0}
+        real_ctor = es.TruePeakDetector
+
+        def _counting_ctor(*args, **kwargs):
+            calls["n"] += 1
+            return real_ctor(*args, **kwargs)
+
+        # Patch the name where each module looks it up (both import es).
+        monkeypatch.setattr(loudness_mod.es, "TruePeakDetector", _counting_ctor)
+        monkeypatch.setattr(problems_mod.es, "TruePeakDetector", _counting_ctor)
+
+        audio = _asymmetric_stereo()
+        analyze_loudness(audio)
+        from phantom.problems import detect_problems
+
+        detect_problems(audio)
+
+        assert calls["n"] == 1, (
+            f"Expected TruePeakDetector constructed exactly once across "
+            f"analyze_loudness + detect_problems on the same AudioData, "
+            f"got {calls['n']}"
+        )

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -507,6 +507,123 @@ class TestMatrixRanking:
 
 
 # ---------------------------------------------------------------------------
+# P-07: Streaming matrix energies (resample -> energies -> drop) parity
+# ---------------------------------------------------------------------------
+
+
+class TestMatrixStreamingParity:
+    """Streaming per-stem resample must yield results identical to batch-align.
+
+    P-07 replaces the up-front ``align_sample_rates(*stems)`` (which holds N
+    resampled copies) with a per-stem ``resample_to_match`` inside the energy
+    loop, dropping each resampled array immediately. Because
+    ``align_sample_rates`` resamples every below-target stem via that same
+    ``resample_to_match(a, target)`` call, the two paths must be numerically
+    identical. These tests reconstruct the batch-align reference independently
+    and assert the matrix output matches it exactly.
+    """
+
+    def _reference_matrix_scores(self, stems):
+        """Compute expected matrix scores via explicit batch-align reference.
+
+        Mirrors the pre-P-07 flow: align every stem to the max rate up front,
+        compute band energies per stem, then run the (unchanged)
+        ``_compute_pairwise_result`` over each combination -- independent of the
+        streaming implementation under test.
+        """
+        import itertools
+
+        from phantom._resample import align_sample_rates
+        from phantom.masking import (
+            _compute_band_energies,
+            _compute_pairwise_result,
+            _no_masking_result,
+        )
+        from phantom._utils import is_near_silent
+
+        aligned = list(align_sample_rates(*stems))
+        energies: list = []
+        for stem in aligned:
+            mono = stem.mono
+            if is_near_silent(mono):
+                energies.append(None)
+            else:
+                energies.append(_compute_band_energies(mono, stem.sample_rate))
+
+        expected = {}
+        for i, j in itertools.combinations(range(len(aligned)), 2):
+            if energies[i] is None or energies[j] is None:
+                res = _no_masking_result()
+            else:
+                res = _compute_pairwise_result(energies[i], energies[j])
+            expected[("stem_%d" % i, "stem_%d" % j)] = res
+        return expected
+
+    def test_mixed_rate_three_stems_parity(self):
+        """3-stem mixed-rate [44100, 48000, 44100] matrix matches batch-align."""
+        sr1, sr2 = 44100, 48000
+        t1 = np.linspace(0, 1.0, sr1, endpoint=False, dtype=np.float32)
+        t2 = np.linspace(0, 1.0, sr2, endpoint=False, dtype=np.float32)
+        stems = [
+            _make_audio((0.5 * np.sin(2 * np.pi * 300 * t1)).astype(np.float32), sr1),
+            _make_audio((0.5 * np.sin(2 * np.pi * 350 * t2)).astype(np.float32), sr2),
+            _make_audio((0.5 * np.sin(2 * np.pi * 4000 * t1)).astype(np.float32), sr1),
+        ]
+        expected = self._reference_matrix_scores(stems)
+
+        result = analyze_masking_matrix(stems)
+        assert result.pair_count == 3
+        for pair in result.pairs:
+            ref = expected[(pair.stem_a, pair.stem_b)]
+            assert pair.overall_score == ref.overall_score
+            assert pair.overall_severity == ref.overall_severity
+            assert len(pair.bands) == len(ref.bands)
+            for got_band, exp_band in zip(pair.bands, ref.bands):
+                assert got_band.band == exp_band.band
+                assert got_band.overlap_score == exp_band.overlap_score
+                assert got_band.severity == exp_band.severity
+
+    def test_matched_rate_three_stems_parity(self):
+        """Same-rate 3-stem matrix (no resample) matches batch-align reference."""
+        sr = 44100
+        t = np.linspace(0, 1.0, sr, endpoint=False, dtype=np.float32)
+        stems = [
+            _make_audio((0.5 * np.sin(2 * np.pi * 300 * t)).astype(np.float32), sr),
+            _make_audio((0.5 * np.sin(2 * np.pi * 350 * t)).astype(np.float32), sr),
+            _make_audio((0.5 * np.sin(2 * np.pi * 4000 * t)).astype(np.float32), sr),
+        ]
+        expected = self._reference_matrix_scores(stems)
+
+        result = analyze_masking_matrix(stems)
+        for pair in result.pairs:
+            ref = expected[(pair.stem_a, pair.stem_b)]
+            assert pair.overall_score == ref.overall_score
+            for got_band, exp_band in zip(pair.bands, ref.bands):
+                assert got_band.overlap_score == exp_band.overlap_score
+
+    def test_mixed_rate_with_silent_stem_parity(self):
+        """Mixed-rate matrix with a near-silent stem matches batch-align reference."""
+        sr1, sr2 = 44100, 48000
+        t1 = np.linspace(0, 1.0, sr1, endpoint=False, dtype=np.float32)
+        t2 = np.linspace(0, 1.0, sr2, endpoint=False, dtype=np.float32)
+        stems = [
+            _make_audio((0.5 * np.sin(2 * np.pi * 300 * t1)).astype(np.float32), sr1),
+            _make_audio((1e-5 * np.sin(2 * np.pi * 350 * t2)).astype(np.float32), sr2),
+            _make_audio((0.5 * np.sin(2 * np.pi * 4000 * t1)).astype(np.float32), sr1),
+        ]
+        expected = self._reference_matrix_scores(stems)
+
+        result = analyze_masking_matrix(stems)
+        assert result.pair_count == 3
+        for pair in result.pairs:
+            ref = expected[(pair.stem_a, pair.stem_b)]
+            assert pair.overall_score == ref.overall_score
+            assert pair.overall_severity == ref.overall_severity
+            for got_band, exp_band in zip(pair.bands, ref.bands):
+                assert got_band.overlap_score == exp_band.overlap_score
+
+
+# ---------------------------------------------------------------------------
 # Band Energies Edge Cases (sub-frame audio)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -82,6 +82,55 @@ def identical_stems():
 
 
 # ---------------------------------------------------------------------------
+# P-09: Shared octave-band-energy helper (pure dedup, no numeric change)
+# ---------------------------------------------------------------------------
+
+
+class TestBandEnergyHelperParity:
+    """Verify _compute_band_energies is numerically unchanged after dedup (P-09)."""
+
+    # Golden values captured from the pre-refactor _compute_band_energies on
+    # seeded broadband noise (rng=42, amplitude 0.3, sr=44100). Extracting the
+    # 4096/2048 Hann + FrequencyBands loop into spectral._octave_band_energies
+    # must not alter these numbers.
+    _GOLDEN = np.array(
+        [
+            0.0002778951311483979,
+            0.0005883493577130139,
+            0.0010133546311408281,
+            0.001955181360244751,
+            0.003989834804087877,
+            0.007407692261040211,
+            0.016881804913282394,
+            0.03203596919775009,
+            0.06603545695543289,
+            0.12378077954053879,
+        ],
+        dtype=np.float32,
+    )
+
+    def test_band_energies_match_golden(self):
+        """Band energies for seeded noise must match pre-refactor golden values."""
+        sr = 44100
+        rng = np.random.default_rng(42)
+        noise = rng.standard_normal(sr).astype(np.float32) * 0.3
+        energies = _compute_band_energies(noise, sr)
+        assert energies.shape == self._GOLDEN.shape
+        assert np.allclose(energies, self._GOLDEN, rtol=0, atol=0)
+
+    def test_delegates_to_spectral_helper(self):
+        """_compute_band_energies delegates to spectral._octave_band_energies."""
+        from phantom import spectral
+
+        sr = 44100
+        rng = np.random.default_rng(7)
+        noise = rng.standard_normal(sr).astype(np.float32) * 0.3
+        via_masking = _compute_band_energies(noise, sr)
+        via_spectral = spectral._octave_band_energies(noise, sr)
+        assert np.allclose(via_masking, via_spectral, rtol=0, atol=0)
+
+
+# ---------------------------------------------------------------------------
 # MASK-01: Pairwise Masking Analysis
 # ---------------------------------------------------------------------------
 

--- a/tests/test_masking.py
+++ b/tests/test_masking.py
@@ -116,7 +116,8 @@ class TestBandEnergyHelperParity:
         noise = rng.standard_normal(sr).astype(np.float32) * 0.3
         energies = _compute_band_energies(noise, sr)
         assert energies.shape == self._GOLDEN.shape
-        assert np.allclose(energies, self._GOLDEN, rtol=0, atol=0)
+        # Tight tolerance for cross-platform float32 ULP wobble (Linux vs macOS Essentia)
+        assert np.allclose(energies, self._GOLDEN, rtol=1e-5, atol=1e-9)
 
     def test_delegates_to_spectral_helper(self):
         """_compute_band_energies delegates to spectral._octave_band_energies."""

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -22,6 +22,7 @@ from phantom.problems import (
     _detect_lossy_codec,
     _spectral_flatness,
     _average_power_spectrum,
+    _DC_OFFSET_THRESHOLD,
 )
 
 
@@ -211,6 +212,39 @@ class TestDCOffset:
         samples, sr = mono_sine_440hz
         samples = samples * 0.5
         audio = _make_audio(samples.astype(np.float32), sr)
+        result = detect_problems(audio)
+        dc_problems = [p for p in result.problems if p.type == "dc_offset"]
+        assert len(dc_problems) == 0
+
+    def test_antiphase_stereo_dc_detected(self):
+        """Antiphase DC (L=+0.1, R=-0.1) cancels in mono but must still flag (P-13).
+
+        The mono mixdown of a +x/-x DC pair is zero, so a mono-only check
+        misses it. Per-channel detection flags it because either channel
+        exceeds the threshold.
+        """
+        sr = 44100
+        t = np.linspace(0, 1.0, sr, endpoint=False, dtype=np.float32)
+        sine = 0.5 * np.sin(2 * np.pi * 440 * t)
+        left = (sine + 0.1).astype(np.float32)
+        right = (sine - 0.1).astype(np.float32)
+        samples = np.column_stack([left, right])
+        audio = _make_stereo_audio(samples, sr)
+
+        # Sanity: mono mixdown cancels the DC, so a mono-only check sees nothing.
+        assert abs(float(np.mean(audio.mono))) < _DC_OFFSET_THRESHOLD
+
+        result = detect_problems(audio)
+        dc_problems = [p for p in result.problems if p.type == "dc_offset"]
+        assert len(dc_problems) == 1
+
+    def test_clean_stereo_no_dc_offset(self):
+        """Clean stereo sine (no DC on either channel) -> no dc_offset problem."""
+        sr = 44100
+        t = np.linspace(0, 1.0, sr, endpoint=False, dtype=np.float32)
+        sine = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        samples = np.column_stack([sine, sine])
+        audio = _make_stereo_audio(samples, sr)
         result = detect_problems(audio)
         dc_problems = [p for p in result.problems if p.type == "dc_offset"]
         assert len(dc_problems) == 0

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -245,6 +245,40 @@ class TestInterSamplePeaks:
         assert "sample_peak_dbfs" in details
         assert "overshoot_db" in details
 
+    def test_isp_shares_true_peak_and_matches(self):
+        """ISP true_peak_dbtp equals the value derived from shared channel_true_peaks.
+
+        Parity, not a new number: the detail's true_peak_dbtp must match the
+        dBTP computed from the worst channel's shared true peak. Confirms the
+        ISP detector is fed from the same memoized computation loudness uses.
+        """
+        sr = 44100
+        t = np.linspace(0, 1.0, sr, endpoint=False, dtype=np.float32)
+        # 14700Hz near full scale — reliably triggers ISP overshoot.
+        samples = (1.0 * np.sin(2 * np.pi * 14700 * t)).astype(np.float32)
+        audio = _make_audio(samples, sr)
+
+        from phantom._truepeak import channel_true_peaks
+
+        pairs = channel_true_peaks(audio)
+        eps = np.finfo(np.float32).eps
+        # Worst channel by overshoot (matches _detect_inter_sample_peaks logic).
+        worst_tp = 0.0
+        worst_overshoot = 0.0
+        for sp, tp in pairs:
+            overshoot = float(20 * np.log10((tp + eps) / (sp + eps)))
+            if overshoot > worst_overshoot:
+                worst_overshoot = overshoot
+                worst_tp = tp
+        expected_dbtp = round(float(20 * np.log10(worst_tp + eps)), 2)
+
+        result = detect_problems(audio)
+        isp = [p for p in result.problems if p.type == "inter_sample_peak"]
+        assert len(isp) > 0
+        assert isp[0].details["true_peak_dbtp"] == pytest.approx(
+            expected_dbtp, abs=1e-9
+        )
+
 
 # ---------------------------------------------------------------------------
 # PROB-04: Noise Floor Detection

--- a/tests/test_problems.py
+++ b/tests/test_problems.py
@@ -12,6 +12,9 @@ from unittest.mock import patch
 from phantom.audio import AudioData
 from phantom.problems import (
     detect_problems,
+    inject_sample_rate_mismatch,
+    build_summary,
+    ProblemItem,
     ProblemsResult,
     _detect_hum,
     _detect_band_excess,
@@ -1023,3 +1026,69 @@ class TestFFTSpectrumSharing:
             detect_problems(audio)
             # Should be called exactly once (pre-compute), not 2 times
             assert mock_aps.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Shared sample-rate-mismatch injection (P-10)
+# ---------------------------------------------------------------------------
+
+
+class TestInjectSampleRateMismatch:
+    """Tests for inject_sample_rate_mismatch shared helper (P-10)."""
+
+    def test_prepends_dealbreaker_and_rebuilds(self):
+        """Given a clean ProblemsResult and a 2-rate dict, the returned result
+        has the mismatch item first, clean=False, and summary counts updated."""
+        clean = ProblemsResult()  # empty problems, clean=True
+        assert clean.clean is True
+        assert clean.summary.total == 0
+
+        sample_rates = {"kick.wav": 44100, "vox.wav": 48000}
+        result = inject_sample_rate_mismatch(clean, sample_rates)
+
+        # New result -- a fresh ProblemsResult, not the same object mutated
+        assert isinstance(result, ProblemsResult)
+        assert result is not clean
+
+        # Mismatch item is FIRST
+        assert result.problems[0].type == "sample_rate_mismatch"
+        assert result.problems[0].severity == "dealbreaker"
+
+        # clean flipped to False
+        assert result.clean is False
+
+        # Summary counts updated
+        assert result.summary.dealbreaker == 1
+        assert result.summary.total == 1
+
+    def test_injected_item_message_and_details(self):
+        """The injected item's message and details match the byte-identical
+        structure produced at both former call sites."""
+        sample_rates = {"a.wav": 44100, "b.wav": 96000}
+        result = inject_sample_rate_mismatch(ProblemsResult(), sample_rates)
+
+        expected_detail = {"a.wav": 44100, "b.wav": 96000}
+        item = result.problems[0]
+        assert item.message == f"Sample rate mismatch across stems: {expected_detail}"
+        assert item.details == {"sample_rates": expected_detail}
+
+    def test_preserves_existing_problems_after_mismatch(self):
+        """Existing problems are preserved and follow the prepended mismatch item."""
+        existing = ProblemItem(
+            type="clipping",
+            severity="dealbreaker",
+            message="Clipping detected.",
+            details={"clipped_samples": 5},
+        )
+        original = ProblemsResult(
+            problems=[existing],
+            clean=False,
+            summary=build_summary([existing]),
+        )
+
+        result = inject_sample_rate_mismatch(original, {"a.wav": 44100, "b.wav": 48000})
+
+        assert result.problems[0].type == "sample_rate_mismatch"
+        assert result.problems[1] is existing
+        assert result.summary.dealbreaker == 2
+        assert result.summary.total == 2

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1008,3 +1008,141 @@ class TestFixAudio:
 
         with pytest.raises(DependencyMissingError):
             fix_audio(stereo_wav)
+
+
+# ---------------------------------------------------------------------------
+# TestFixAudioPreloaded -- P-08: additive `audio=` param skips input re-decode
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.skipif(not _has_pedalboard, reason="pedalboard not installed")
+class TestFixAudioPreloaded:
+    """fix_audio(audio=...) reuses an already-loaded AudioData for the input.
+
+    P-08: the interactive CLI path decodes the input once for detect_problems,
+    then fix_audio decodes it again. The additive keyword-only `audio` param lets
+    the caller thread the already-loaded AudioData so the input is decoded once.
+    Behavior with audio=None must be byte-identical to the pre-P-08 function.
+    """
+
+    @pytest.fixture()
+    def stereo_wav(self, tmp_path):
+        """Create a stereo WAV file with a 440Hz sine (matches TestFixAudio)."""
+        sr = 44100
+        duration = 0.5
+        n = int(sr * duration)
+        t = np.linspace(0, duration, n, endpoint=False, dtype=np.float32)
+        samples = (0.5 * np.sin(2 * np.pi * 440 * t)).astype(np.float32)
+        samples_2d = np.column_stack([samples, samples])
+        path = str(tmp_path / "input.wav")
+        sf.write(path, samples_2d, sr)
+        return path
+
+    def test_preloaded_audio_matches_default(self, stereo_wav, tmp_path, monkeypatch):
+        """Result is identical whether `audio` is passed or loaded internally."""
+        from phantom.processing import fix_audio
+        from phantom.audio import load_audio
+        from phantom.problems import ProblemsResult, ProblemItem
+
+        before_result = ProblemsResult(
+            problems=[
+                ProblemItem(type="mud", severity="moderate", message="Mud", details={})
+            ],
+            clean=False,
+        )
+        after_result = ProblemsResult(problems=[], clean=True)
+
+        # Deterministic detect keyed on call order: first call is "before" (on
+        # the input), second is "after" (on the freshly written output).
+        calls = {"n": 0}
+
+        def ordered_detect(audio):
+            calls["n"] += 1
+            return before_result if calls["n"] == 1 else after_result
+
+        # Path A: default (audio=None) -- fix_audio loads internally.
+        monkeypatch.setattr("phantom.processing.detect_problems", ordered_detect)
+        out_a = str(tmp_path / "out_a.wav")
+        result_default = fix_audio(stereo_wav, output_path=out_a)
+
+        # Path B: pre-load and pass audio=...
+        calls["n"] = 0
+        preloaded = load_audio(stereo_wav)
+        out_b = str(tmp_path / "out_b.wav")
+        result_preloaded = fix_audio(stereo_wav, output_path=out_b, audio=preloaded)
+
+        # Results must be identical except for the (intentionally different)
+        # output_path. Compare the rest of the model.
+        dump_a = result_default.model_dump()
+        dump_b = result_preloaded.model_dump()
+        dump_a.pop("output_path")
+        dump_b.pop("output_path")
+        assert dump_a == dump_b
+
+        # And the written audio bytes must match.
+        import soundfile as sf_
+
+        samples_a, sr_a = sf_.read(out_a)
+        samples_b, sr_b = sf_.read(out_b)
+        assert sr_a == sr_b
+        assert np.array_equal(samples_a, samples_b)
+
+    def test_preloaded_audio_skips_input_load(self, stereo_wav, tmp_path, monkeypatch):
+        """When audio= is provided, the input file is not re-decoded.
+
+        fix_audio still loads the *output* for after-detection, so exactly one
+        load_audio call happens (output only) instead of two (input + output).
+        """
+        from phantom.processing import fix_audio
+        from phantom.audio import load_audio
+        from phantom.problems import ProblemsResult
+
+        monkeypatch.setattr(
+            "phantom.processing.detect_problems",
+            lambda audio: ProblemsResult(problems=[], clean=True),
+        )
+
+        preloaded = load_audio(stereo_wav)
+
+        loaded_paths: list[str] = []
+        real_load = load_audio
+
+        def tracking_load(path):
+            loaded_paths.append(path)
+            return real_load(path)
+
+        monkeypatch.setattr("phantom.processing.load_audio", tracking_load)
+
+        output = str(tmp_path / "output.wav")
+        result = fix_audio(stereo_wav, output_path=output, audio=preloaded)
+
+        # Only the output was loaded (for after-detection); the input was reused.
+        assert result.output_path == output
+        assert len(loaded_paths) == 1
+        assert os.path.realpath(loaded_paths[0]) == os.path.realpath(output)
+
+    def test_default_still_loads_input(self, stereo_wav, tmp_path, monkeypatch):
+        """With audio=None, both input and output are loaded (unchanged behavior)."""
+        from phantom.processing import fix_audio
+        from phantom.audio import load_audio
+        from phantom.problems import ProblemsResult
+
+        monkeypatch.setattr(
+            "phantom.processing.detect_problems",
+            lambda audio: ProblemsResult(problems=[], clean=True),
+        )
+
+        loaded_paths: list[str] = []
+        real_load = load_audio
+
+        def tracking_load(path):
+            loaded_paths.append(path)
+            return real_load(path)
+
+        monkeypatch.setattr("phantom.processing.load_audio", tracking_load)
+
+        output = str(tmp_path / "output.wav")
+        fix_audio(stereo_wav, output_path=output)
+
+        # Input + output both loaded: two calls, unchanged from pre-P-08.
+        assert len(loaded_paths) == 2

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -14,7 +14,7 @@ import numpy as np
 import pytest
 
 from phantom.audio import AudioData
-from phantom._resample import resample_to_match
+from phantom._resample import align_sample_rates, resample_to_match
 
 
 def _make_audio(
@@ -208,3 +208,29 @@ class TestInfoLogging:
         msgs = " ".join(r.message for r in caplog.records)
         assert "44100" in msgs
         assert "48000" in msgs
+
+
+# --- align_sample_rates helper ---
+
+
+class TestAlignSampleRates:
+    """Upsample all inputs to the highest sample rate; identity when equal."""
+
+    def test_mismatched_rates_upsampled_in_order(self) -> None:
+        audio_a = _make_audio(_sine(440.0, 44100), 44100)
+        audio_b = _make_audio(_sine(440.0, 48000), 48000)
+        out_a, out_b = align_sample_rates(audio_a, audio_b)
+        # Both aligned to the higher rate.
+        assert out_a.sample_rate == 48000
+        assert out_b.sample_rate == 48000
+        # Input order preserved: the already-48000 input is returned unchanged.
+        assert out_b is audio_b
+        # The lower-rate input was resampled to a new object.
+        assert out_a is not audio_a
+
+    def test_equal_rates_return_identical_objects(self) -> None:
+        audio_a = _make_audio(_sine(440.0, 44100), 44100)
+        audio_b = _make_audio(_sine(220.0, 44100), 44100)
+        out_a, out_b = align_sample_rates(audio_a, audio_b)
+        assert out_a is audio_a
+        assert out_b is audio_b

--- a/tests/test_separation.py
+++ b/tests/test_separation.py
@@ -256,6 +256,43 @@ class TestSeparateStems:
                     output_dir=str(tmp_path / "out"),
                 )
 
+    def test_silent_input_raises_analysis_error(self, tmp_path, wav_file_factory):
+        """Fully-silent input (ref.std() == 0) raises a clean AnalysisError, not NaN (P-14).
+
+        Without the zero-std guard, ``(wav - ref.mean()) / ref.std()`` divides by
+        zero and feeds NaNs into demucs. The guard must intercept it first with a
+        musician-friendly message.
+        """
+        sr = 44100
+        # A genuinely silent file: all zeros. (The mock's ref.std() is forced to
+        # 0.0 below so the guard fires regardless of demucs internals.)
+        samples = np.zeros((sr, 2), dtype=np.float32)
+        input_path = wav_file_factory(samples, sr)
+        output_dir = str(tmp_path / "stems")
+
+        mocks = _make_demucs_mocks()
+        # Force the demucs reference channel to report zero standard deviation,
+        # simulating a fully-silent input reaching the normalization step.
+        mocks[
+            "demucs.audio"
+        ].AudioFile.return_value.read.return_value.mean.return_value = MagicMock(
+            mean=MagicMock(return_value=0.0),
+            std=MagicMock(return_value=0.0),
+        )
+
+        with patch.dict(
+            "sys.modules",
+            {
+                "demucs.pretrained": mocks["demucs.pretrained"],
+                "demucs.apply": mocks["demucs.apply"],
+                "demucs.audio": mocks["demucs.audio"],
+                "demucs": mocks["demucs"],
+                "torch": mocks["torch"],
+            },
+        ):
+            with pytest.raises(AnalysisError, match="silent"):
+                separate_stems(input_path, output_dir)
+
     def test_import_without_demucs(self, monkeypatch):
         """Importing phantom.separation without demucs installed does not raise (SEP-02)."""
         import builtins

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -517,8 +517,7 @@ def test_full_diagnostic_populates_cache(mono_sine_440hz, make_wav):
     from phantom.server import full_diagnostic
 
     # Start from a clean cache so the assertions reflect this call only.
-    with analysis_cache._lock:
-        analysis_cache._store.clear()
+    analysis_cache.clear()
 
     samples, sr = mono_sine_440hz
     path = make_wav(samples, sr)
@@ -534,8 +533,7 @@ def test_full_diagnostic_populates_cache(mono_sine_440hz, make_wav):
     assert analysis_cache.get(audio, "detect_problems") is not _MISSING
 
     # Clean up so we don't leak entries into other tests sharing the cache.
-    with analysis_cache._lock:
-        analysis_cache._store.clear()
+    analysis_cache.clear()
 
 
 async def test_batch_diagnostic_rebuild_problems(client, mono_sine_440hz, make_wav):

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -503,6 +503,41 @@ async def test_full_diagnostic_typed_sections(client, mono_sine_440hz, make_wav)
     assert isinstance(data["duration_seconds"], float)
 
 
+def test_full_diagnostic_populates_cache(mono_sine_440hz, make_wav):
+    """full_diagnostic routes its analyzers through the shared analysis cache (P-01).
+
+    After running full_diagnostic, the per-analyzer results for that audio
+    content must be present in the cross-call analysis_cache, so a subsequent
+    compare_to_profile/compare_to_reference on the same bytes reuses the work.
+    The cache key is content-based (SHA-256 of sample bytes + sr + channels +
+    func name), so re-loading the same file hits the same entries.
+    """
+    from phantom._cache import _MISSING, analysis_cache
+    from phantom.audio import load_audio
+    from phantom.server import full_diagnostic
+
+    # Start from a clean cache so the assertions reflect this call only.
+    with analysis_cache._lock:
+        analysis_cache._store.clear()
+
+    samples, sr = mono_sine_440hz
+    path = make_wav(samples, sr)
+    full_diagnostic(path)
+
+    # Re-load the same file; the content hash must match the cached entries.
+    audio = load_audio(path)
+    assert analysis_cache.get(audio, "analyze_spectrum") is not _MISSING
+    assert analysis_cache.get(audio, "analyze_loudness") is not _MISSING
+    assert analysis_cache.get(audio, "analyze_dynamics") is not _MISSING
+    assert analysis_cache.get(audio, "analyze_stereo") is not _MISSING
+    assert analysis_cache.get(audio, "analyze_phase") is not _MISSING
+    assert analysis_cache.get(audio, "detect_problems") is not _MISSING
+
+    # Clean up so we don't leak entries into other tests sharing the cache.
+    with analysis_cache._lock:
+        analysis_cache._store.clear()
+
+
 async def test_batch_diagnostic_rebuild_problems(client, mono_sine_440hz, make_wav):
     """batch_diagnostic with SR mismatch rebuilds ProblemsResult via _build_summary (SC-5)."""
     samples_44k, _ = mono_sine_440hz


### PR DESCRIPTION
## Fix Phantom audit findings (2026-07-05)

Addresses all 22 findings from the 2026-07-05 audit: 1 crash bug, 2 High-value perf
wins, and a batch of Medium/Low robustness, duplication, and polish items.

### Highlights
- **P-11 (crash):** `phantom update` no longer crashes on pre-release release tags (`1.2.3-rc1`, `1.2.0b1`, `2.0.0-beta`).
- **P-02/P-01/P-03 (perf):** the ×4-oversampled true-peak is now computed **once** per file (was twice), and the mono mixdown, full-signal RMS, and content hash are memoized. `full_diagnostic` on a 60 s stereo file is **36.5% faster** (before: 3283.9 ms → after: 2085.7 ms cold; repeat analyses of the same bytes now hit the analysis cache at ~14 ms; see `scripts/bench_full_diagnostic.py`).
- **CLI robustness:** uninstall reports failed removals instead of false success; all `uv` calls have timeouts; error output no longer leaks absolute paths; render can no longer overwrite its own source file (including same-inode/case-variant collisions).

### No breaking API changes
All 18 MCP tool response schemas are preserved (independently verified against main — zero keys added/removed/renamed). Two intended value-level changes:
- `dynamics.dynamic_range_db` returns `null` (was `0.0`) for unmeasurably short audio (P-12).
- Stereo files with per-channel DC offset are now detected (P-13) — previously antiphase/asymmetric DC canceled in the mono mixdown and was missed; the `dc_offset` problem's details gain an additive `channel` key on this new path.

### Deferrals (documented, evidence-based)
- **P-05** single-pass spectral: profiled — band pass is 12.7% of `analyze_spectrum` but ~0.7% of `full_diagnostic`; not worth the numeric-drift risk. Probe committed.
- **P-18** update-fallback exit-code rewrite: pinned with tests instead (uv wording change would surface via the lock tests).
- `AnalysisCache(max_entries=8)` left unchanged (batch churn is acceptable LRU behavior; bumping is a memory-vs-hitrate tradeoff needing sign-off).

### Testing
- 52 new tests (all synthetic fixtures, no real audio). Full suite: **1036 passed, 47 skipped** (baseline: 984 passed, 44 skipped; the 3 extra skips are new pedalboard-gated parity tests).
- Timing evidence and a per-file "true-peak computed once" regression test included.
- Independently verified vs main: byte-identical loudness/problems/dynamics outputs on synthetic fixtures; identical MCP tool list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


