### PR TITLE
fix(install): send stable per-run id (iid) with telemetry pings

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -107,9 +107,11 @@ main() {
     ok "Detected ${PLATFORM} ${ARCH_LABEL}"
 
     # ── Telemetry (opt-out via PHANTOM_NO_TELEMETRY=1) ─────
+    # Stable per-run id so install_started/install_complete can be joined server-side.
+    INSTALL_ID="$(uuidgen 2>/dev/null || echo "cli-$(date +%s)-$$-${RANDOM}")"
     _ping() {
         if [ "${PHANTOM_NO_TELEMETRY:-0}" = "1" ]; then return; fi
-        curl -sfL "https://fadelab.net/api/ping?event=$1&os=${PLATFORM}&arch=${ARCH_LABEL}&version=${2:-unknown}&extras=${INSTALL_EXTRAS:-none}" > /dev/null 2>&1 &
+        curl -sfL "https://fadelab.net/api/ping?event=$1&os=${PLATFORM}&arch=${ARCH_LABEL}&version=${2:-unknown}&extras=${INSTALL_EXTRAS:-none}&iid=${INSTALL_ID}" > /dev/null 2>&1 &
     }
     _ping "install_started"
 

--- a/uv.lock
+++ b/uv.lock
@@ -1256,7 +1256,7 @@ wheels = [
 
 [[package]]
 name = "mcp"
-version = "1.27.0"
+version = "1.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -1274,9 +1274,9 @@ dependencies = [
     { name = "typing-inspection" },
     { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/eb/c0cfc62075dc6e1ec1c64d352ae09ac051d9334311ed226f1f425312848a/mcp-1.27.0.tar.gz", hash = "sha256:d3dc35a7eec0d458c1da4976a48f982097ddaab87e278c5511d5a4a56e852b83", size = 607509, upload-time = "2026-04-02T14:48:08.88Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6e/77/9450b8f251a13affb6281997d0523c4615f8a8b35d0b21ff30db3a5aac9d/mcp-1.28.1.tar.gz", hash = "sha256:d51e36a5f5644faea4f85ea649bfffa6bc6c26770d42798ad6a3de3d2ba69683", size = 638501, upload-time = "2026-06-26T12:57:29.093Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9c/46/f6b4ad632c67ef35209a66127e4bddc95759649dd595f71f13fba11bdf9a/mcp-1.27.0-py3-none-any.whl", hash = "sha256:5ce1fa81614958e267b21fb2aa34e0aea8e2c6ede60d52aba45fd47246b4d741", size = 215967, upload-time = "2026-04-02T14:48:07.24Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/5e/d118fce19f87a2e7d8101c35c8ae0ec289098a4df0ff244cec23e415aca0/mcp-1.28.1-py3-none-any.whl", hash = "sha256:2726bca5e7193f61c5dde8b12500a6de2d9acf6d1a1c0be9e8c2e706437991df", size = 222620, upload-time = "2026-06-26T12:57:27.218Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The installer's `install_started` and `install_complete` pings each hit `fadelab.net/api/ping`, which minted a fresh `cli-${Date.now()}` distinct_id **per request** — so the two events from one install never shared identity and couldn't be joined into a funnel.

This mints one `INSTALL_ID` per run (`uuidgen`, with a portable fallback) and passes it as `&iid=` on both pings. The server side (fadelab.net `api/ping.ts`) already ships the matching change to use `iid` as the PostHog `distinct_id`, falling back to the old scheme for older clients.

## Effect

`install_started → install_complete` becomes a real person-funnel (true install-reliability rate). Backward-compatible: old clients omit `iid` and keep working (just unjoinable, as before). Clean funnel data starts from deploy.

## Notes

- Opt-out via `PHANTOM_NO_TELEMETRY=1` unchanged.
- No behavior change to the install itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)